### PR TITLE
Fix backend linting errors reported by ruff.

### DIFF
--- a/python/src/server/api_routes/knowledge_api.py
+++ b/python/src/server/api_routes/knowledge_api.py
@@ -14,20 +14,20 @@ import json
 import uuid
 from datetime import datetime
 
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile, Header
+from fastapi import APIRouter, File, Form, Header, HTTPException, UploadFile
 from pydantic import BaseModel
 
 # Import unified logging
 from ..config.logfire_config import get_logger, safe_logfire_error, safe_logfire_info
+from ..models.blog import BlogPostResponse, CreateBlogPostRequest, UpdateBlogPostRequest
+from ..services.blog_service import BlogService
 from ..services.crawler_manager import get_crawler
 from ..services.crawling import CrawlOrchestrationService
 from ..services.knowledge import DatabaseMetricsService, KnowledgeItemService
 from ..services.knowledge_service import KnowledgeService
+from ..services.rbac_service import RBACService
 from ..services.search.rag_service import RAGService
 from ..services.storage import DocumentStorageService
-from ..services.blog_service import BlogService
-from ..models.blog import CreateBlogPostRequest, UpdateBlogPostRequest, BlogPostResponse
-from ..services.rbac_service import RBACService
 from ..utils import get_supabase_client
 from ..utils.document_processing import extract_text_from_document
 from ..utils.progress.progress_tracker import ProgressTracker
@@ -68,7 +68,7 @@ async def create_blog_post(
     current_user_role = x_user_role or "User"
     if not rbac_service.can_manage_content(current_user_role):
         raise HTTPException(status_code=403, detail="Forbidden: You do not have permission to create blog posts.")
-    
+
     blog_service = BlogService()
     success, result = await blog_service.create_post(request.model_dump())
     if not success:

--- a/python/src/server/models/blog.py
+++ b/python/src/server/models/blog.py
@@ -1,16 +1,17 @@
 # python/src/server/models/blog.py
 
-from pydantic import BaseModel, Field
-from typing import Optional
 from datetime import datetime
+
+from pydantic import BaseModel, Field
+
 
 class BlogPostBase(BaseModel):
     title: str
-    excerpt: Optional[str] = None
+    excerpt: str | None = None
     content: str
-    author_name: Optional[str] = Field(None, alias='authorName')
-    publish_date: Optional[datetime] = Field(None, alias='publishDate')
-    image_url: Optional[str] = Field(None, alias='imageUrl')
+    author_name: str | None = Field(None, alias='authorName')
+    publish_date: datetime | None = Field(None, alias='publishDate')
+    image_url: str | None = Field(None, alias='imageUrl')
 
     class Config:
         populate_by_name = True
@@ -20,14 +21,14 @@ class CreateBlogPostRequest(BlogPostBase):
     pass
 
 class UpdateBlogPostRequest(BaseModel):
-    title: Optional[str] = None
-    excerpt: Optional[str] = None
-    content: Optional[str] = None
-    author_name: Optional[str] = Field(None, alias='authorName')
-    publish_date: Optional[datetime] = Field(None, alias='publishDate')
-    image_url: Optional[str] = Field(None, alias='imageUrl')
+    title: str | None = None
+    excerpt: str | None = None
+    content: str | None = None
+    author_name: str | None = Field(None, alias='authorName')
+    publish_date: datetime | None = Field(None, alias='publishDate')
+    image_url: str | None = Field(None, alias='imageUrl')
 
 class BlogPostResponse(BlogPostBase):
     id: str
     created_at: datetime = Field(alias='createdAt')
-    updated_at: Optional[datetime] = Field(None, alias='updatedAt')
+    updated_at: datetime | None = Field(None, alias='updatedAt')

--- a/python/src/server/services/blog_service.py
+++ b/python/src/server/services/blog_service.py
@@ -1,8 +1,9 @@
 # python/src/server/services/blog_service.py
 
-from ..utils import get_supabase_client
+from typing import Any
+
 from ..config.logfire_config import get_logger
-from typing import Any, Tuple
+from ..utils import get_supabase_client
 
 logger = get_logger(__name__)
 
@@ -12,7 +13,7 @@ class BlogService:
     def __init__(self):
         self.supabase = get_supabase_client()
 
-    async def list_posts(self) -> Tuple[bool, dict[str, Any]]:
+    async def list_posts(self) -> tuple[bool, dict[str, Any]]:
         """Retrieve a list of all blog posts."""
         try:
             response = self.supabase.table("blog_posts").select("id, title, excerpt, author_name, publish_date, image_url").order("publish_date", desc=True).execute()
@@ -23,7 +24,7 @@ class BlogService:
             logger.error(f"Error listing blog posts: {e}", exc_info=True)
             return False, {"error": str(e)}
 
-    async def get_post(self, post_id: str) -> Tuple[bool, dict[str, Any]]:
+    async def get_post(self, post_id: str) -> tuple[bool, dict[str, Any]]:
         """Retrieve a single blog post by its ID."""
         try:
             response = self.supabase.table("blog_posts").select("*").eq("id", post_id).single().execute()
@@ -34,7 +35,7 @@ class BlogService:
             logger.error(f"Error getting post {post_id}: {e}", exc_info=True)
             return False, {"error": str(e)}
 
-    async def create_post(self, post_data: dict[str, Any]) -> Tuple[bool, dict[str, Any]]:
+    async def create_post(self, post_data: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
         """Create a new blog post."""
         try:
             response = self.supabase.table("blog_posts").insert(post_data).select().single().execute()
@@ -45,7 +46,7 @@ class BlogService:
             logger.error(f"Error creating post: {e}", exc_info=True)
             return False, {"error": str(e)}
 
-    async def update_post(self, post_id: str, update_data: dict[str, Any]) -> Tuple[bool, dict[str, Any]]:
+    async def update_post(self, post_id: str, update_data: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
         """Update an existing blog post."""
         try:
             response = self.supabase.table("blog_posts").update(update_data).eq("id", post_id).select().single().execute()
@@ -56,7 +57,7 @@ class BlogService:
             logger.error(f"Error updating post {post_id}: {e}", exc_info=True)
             return False, {"error": str(e)}
 
-    async def delete_post(self, post_id: str) -> Tuple[bool, dict[str, Any]]:
+    async def delete_post(self, post_id: str) -> tuple[bool, dict[str, Any]]:
         """Delete a blog post."""
         try:
             response = self.supabase.table("blog_posts").delete().eq("id", post_id).execute()

--- a/python/tests/server/api_routes/test_knowledge_api_blog.py
+++ b/python/tests/server/api_routes/test_knowledge_api_blog.py
@@ -1,8 +1,10 @@
 # python/tests/server/api_routes/test_knowledge_api_blog.py
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import AsyncMock, patch
+
 
 @pytest.fixture
 def client():


### PR DESCRIPTION
This commit addresses multiple linting issues across the backend codebase, including:
- Unsorted imports
- Modernized type hints (Optional[T] -> T | None)
- Use of `tuple` instead of `typing.Tuple`
- Removal of trailing whitespace and addition of missing newlines.

make test-be and make lint-be passed