### PR TITLE
修正 RAGSettings 組件中的初始化順序錯誤

### DIFF
--- a/archon-ui-main/pnpm-lock.yaml
+++ b/archon-ui-main/pnpm-lock.yaml
@@ -44,9 +44,15 @@ importers:
       '@radix-ui/react-toast':
         specifier: ^1.2.15
         version: 1.2.15(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle-group':
+        specifier: ^1.1.0
+        version: 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-visually-hidden':
+        specifier: ^1.1.0
+        version: 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^5.85.8
         version: 5.90.5(react@18.3.1)


### PR DESCRIPTION
將 `fetchOllamaMetrics` 函式的定義移至 `manualTestConnection` 之前，以解決因「暫時性死區 (TDZ)」造成的 `ReferenceError`，確保組件能夠正常渲染。

# Pull Request

Merge: stabilize RAGSettings init and memoize Ollama checks (prefer fix-ragsettings-init-error)
PR 說明（body）

## 概要
將 fix-ragsettings-init-error 的變更合併到 dev/v1。此分支修正了 RAGSettings 元件的初始化順序與重複網路檢查問題，並將關鍵的網路/metrics 函式用 useCallback memoize，以避免在 render 循環中重建函式導致 useEffect 不必要重跑或初始化錯誤。
## 主要變更
fetchOllamaMetrics 與 manualTestConnection 改為 useCallback 並上移宣告，避免被 useEffect 依賴時造成不必要的重跑。
減少或移除多餘的 console.log / console.error，改以 showToast 回饋使用者（更適合生產環境）。
調整初始化流程（hasRunInitialTestRef、staggered setTimeout）以避免在 ragSettings 尚未載入時觸發 health-checks，修復 init error。
移除/註解掉 window.confirm 呼叫（刪除 LLM/Embedding instance 時不再跳確認對話框）。（注意：這是行為變更）
修正部分 useEffect 依賴以降低無限 loop / 重複執行風險。
為什麼採用 fix-ragsettings-init-error 比較好
減少初始化時不穩定的網路請求（避免 UI 在載入時噴出錯誤）。
memoize 關鍵函式能穩定 useEffect 行為，降低重複呼叫與重試循環。
更清晰的邏輯順序，方便維護與除錯。
## 風險
刪除確認對話框會改變使用者流程（可能造成誤刪），建議在合併前討論是否恢復或替換為 modal。
減少 console 訊息會影響開發時的即時診斷，必要時可把 debug log 加回或在 dev 環境開啟更多 log。
請注意 useCallback 的依賴陣列是否涵蓋所有必要變數，避免 stale closure（建議執行 TypeScript + ESLint 檢查）。
## 測試步驟（QA）
在本分支 build 並在 dev 環境打開 Settings -> RAG Settings 頁面，確認頁面載入無例外與錯誤。
切換 chat/embedding provider（含 Ollama 與非 Ollama），確認 UI 權狀態、模型選單與提示正常。
若選 Ollama：點 Test Connection，確認一次成功/失敗 toast 與 status 更新；不要出現重複大量網路請求。
編輯 LLM / Embedding instance（名稱/URL），按 Save Settings，確認設定儲存並回填 UI。
執行刪除 instance（LLM/Embedding），確認是否需要保留確認流程；若不希望立即刪除，請在 PR 中加回確認 modal。
在 dev tools 觀察是否有重複 fetch / setInterval 的過度呼叫行為。
## 建議 reviewers
@info-vin（你自己）與曾處理 RAGSettings 或 Ollama 整合的同事（例如負責 UI 與 backend 的成員）。

type:chore, area:ui, risk:medium

chore/merge-fix-ragsettings-init-error-into-dev_v1
## Commit message 建議（單一 commit）

chore(rag): merge fix-ragsettings-init-error → stabilize RAGSettings init and memoize Ollama checks