### PR TITLE
🎨 Palette: Add loading state to Button component

### DIFF
--- a/archon-ui-main/src/components/ui/Button.test.tsx
+++ b/archon-ui-main/src/components/ui/Button.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Button } from './Button';
+import React from 'react';
+
+describe('Button Component', () => {
+  it('renders children correctly', () => {
+    render(<Button>Click Me</Button>);
+    expect(screen.getByText('Click Me')).toBeInTheDocument();
+  });
+
+  it('handles click events', () => {
+    const handleClick = vi.fn();
+    render(<Button onClick={handleClick}>Click Me</Button>);
+    fireEvent.click(screen.getByText('Click Me'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows loading spinner and is disabled when isLoading is true', () => {
+    render(<Button isLoading>Click Me</Button>);
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+
+    // Look for the spinner. We expect it to have 'animate-spin' class.
+    const spinner = button.querySelector('.animate-spin');
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it('is disabled when the disabled prop is true', () => {
+    render(<Button disabled>Click Me</Button>);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('renders icon when provided', () => {
+    const MockIcon = () => <span data-testid="mock-icon">🔥</span>;
+    render(<Button icon={<MockIcon />}>With Icon</Button>);
+    expect(screen.getByTestId('mock-icon')).toBeInTheDocument();
+    expect(screen.getByText('With Icon')).toBeInTheDocument();
+  });
+
+  it('replaces icon with spinner when isLoading is true', () => {
+    const MockIcon = () => <span data-testid="mock-icon">🔥</span>;
+    render(<Button isLoading icon={<MockIcon />}>With Icon</Button>);
+
+    // Icon should NOT be present (replaced by spinner)
+    expect(screen.queryByTestId('mock-icon')).not.toBeInTheDocument();
+
+    // Spinner SHOULD be present
+    const button = screen.getByRole('button');
+    const spinner = button.querySelector('.animate-spin');
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it('applies disabled styles', () => {
+    render(<Button disabled>Disabled Button</Button>);
+    const button = screen.getByRole('button');
+    // We check for opacity-50 directly as it's applied conditionally in our implementation
+    expect(button.className).toContain('opacity-50');
+    expect(button.className).toContain('cursor-not-allowed');
+  });
+});

--- a/archon-ui-main/src/components/ui/Button.tsx
+++ b/archon-ui-main/src/components/ui/Button.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { cn } from '@/lib/utils';
+
 /**
  * Button - A customizable button component
  *
@@ -12,6 +14,7 @@ export const Button: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement> & {
   accentColor?: 'purple' | 'green' | 'pink' | 'blue' | 'cyan' | 'orange';
   neonLine?: boolean;
   icon?: React.ReactNode;
+  isLoading?: boolean;
 }> = ({
   children,
   variant = 'primary',
@@ -19,7 +22,9 @@ export const Button: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement> & {
   accentColor = 'purple',
   neonLine = false,
   icon,
+  isLoading = false,
   className = '',
+  disabled,
   ...props
 }) => {
   // Size variations
@@ -50,14 +55,23 @@ export const Button: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement> & {
     cyan: 'bg-cyan-500 shadow-[0_0_10px_2px_rgba(34,211,238,0.4)] dark:shadow-[0_0_20px_5px_rgba(34,211,238,0.7)]',
     orange: 'bg-orange-500 shadow-[0_0_10px_2px_rgba(249,115,22,0.4)] dark:shadow-[0_0_20px_5px_rgba(249,115,22,0.7)]'
   };
-  return <button className={`
-        inline-flex items-center justify-center transition-all duration-200
-        ${variantClasses[variant]}
-        ${sizeClasses[size]}
-        ${className}
-      `} {...props}>
+
+  const isDisabled = disabled || isLoading;
+
+  return (
+    <button
+      className={cn(
+        "inline-flex items-center justify-center transition-all duration-200",
+        variantClasses[variant],
+        sizeClasses[size],
+        isDisabled && "opacity-50 cursor-not-allowed pointer-events-none",
+        className
+      )}
+      disabled={isDisabled}
+      {...props}
+    >
       {/* Luminous inner light source for primary variant */}
-      {variant === 'primary' && <>
+      {variant === 'primary' && !isDisabled && <>
           <div className="absolute left-0 right-0 w-[150%] h-[200%] -translate-x-[25%] -translate-y-[30%] opacity-80 group-hover:opacity-100 rounded-[100%] blur-2xl transition-all duration-500 group-hover:scale-110 luminous-button-glow" style={{
         background: `radial-gradient(circle, ${accentColor === 'green' ? 'rgba(16, 185, 129, 0.9)' : accentColor === 'blue' ? 'rgba(59, 130, 246, 0.9)' : accentColor === 'pink' ? 'rgba(236, 72, 153, 0.9)' : accentColor === 'cyan' ? 'rgba(34, 211, 238, 0.9)' : accentColor === 'orange' ? 'rgba(249, 115, 22, 0.9)' : 'rgba(168, 85, 247, 0.9)'} 0%, transparent 70%)`,
         filter: `drop-shadow(0 0 15px ${accentColor === 'green' ? 'rgba(16, 185, 129, 0.8)' : accentColor === 'blue' ? 'rgba(59, 130, 246, 0.8)' : accentColor === 'pink' ? 'rgba(236, 72, 153, 0.8)' : accentColor === 'cyan' ? 'rgba(34, 211, 238, 0.8)' : accentColor === 'orange' ? 'rgba(249, 115, 22, 0.8)' : 'rgba(168, 85, 247, 0.8)'})`
@@ -69,12 +83,22 @@ export const Button: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement> & {
         boxShadow: `0 0 20px 5px ${accentColor === 'green' ? 'rgba(16, 185, 129, 0.6)' : accentColor === 'blue' ? 'rgba(59, 130, 246, 0.6)' : accentColor === 'pink' ? 'rgba(236, 72, 153, 0.6)' : accentColor === 'cyan' ? 'rgba(34, 211, 238, 0.6)' : accentColor === 'orange' ? 'rgba(249, 115, 22, 0.6)' : 'rgba(168, 85, 247, 0.6)'}`
       }} aria-hidden="true" />
         </>}
+
       {/* Content with icon support */}
       <span className="relative z-10 flex items-center justify-center">
-        {icon && <span className="mr-2">{icon}</span>}
+        {isLoading ? (
+          <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+        ) : (
+          icon && <span className="mr-2">{icon}</span>
+        )}
         {children}
       </span>
+
       {/* Optional neon line below button */}
       {neonLine && <span className={`absolute bottom-0 left-[15%] right-[15%] w-[70%] mx-auto h-[2px] ${neonLineColor[accentColor]}`}></span>}
-    </button>;
+    </button>
+  );
 };


### PR DESCRIPTION
This PR adds a loading state to the reusable `Button` component in `archon-ui-main`.

**Changes:**
- `src/components/ui/Button.tsx`: Added `isLoading` prop. When true, the button is disabled, styled as disabled, and displays a spinner. The spinner is an inline SVG to ensure robustness in tests and runtime.
- `src/components/ui/Button.test.tsx`: Added comprehensive unit tests for the Button component, covering rendering, click handling, loading state, disabled state, and icon replacement.

**UX Improvement:**
- Provides immediate visual feedback for async actions.
- Prevents double-submissions by disabling the button.
- Enhances accessibility by managing disabled states correctly.

**Verification:**
- Unit tests passed.
- Visual verification via Playwright script confirmed correct rendering of loading, disabled, and normal states.

---
*PR created automatically by Jules for task [1224401045315509409](https://jules.google.com/task/1224401045315509409) started by @info-vin*