### PR TITLE
🎨 Palette: Dark Mode for EmptyState

### DIFF
--- a/enduser-ui-fe/src/components/common/EmptyState.test.tsx
+++ b/enduser-ui-fe/src/components/common/EmptyState.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { EmptyState } from './EmptyState';
+
+describe('EmptyState', () => {
+  it('renders title and description correctly', () => {
+    render(
+      <EmptyState
+        title="Test Title"
+        description="Test Description"
+      />
+    );
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+    expect(screen.getByText('Test Description')).toBeInTheDocument();
+  });
+
+  it('renders action button and handles click', () => {
+    const handleAction = vi.fn();
+    render(
+      <EmptyState
+        title="Test Title"
+        description="Test Description"
+        actionLabel="Click Me"
+        onAction={handleAction}
+      />
+    );
+
+    const button = screen.getByText('Click Me');
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(handleAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render action button if actionLabel is missing', () => {
+    render(
+      <EmptyState
+        title="Test Title"
+        description="Test Description"
+        onAction={() => {}}
+      />
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders custom icon', () => {
+    render(
+      <EmptyState
+        title="Test Title"
+        description="Test Description"
+        icon={<span data-testid="custom-icon">Icon</span>}
+      />
+    );
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+  });
+});

--- a/enduser-ui-fe/src/components/common/EmptyState.tsx
+++ b/enduser-ui-fe/src/components/common/EmptyState.tsx
@@ -15,19 +15,19 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
     description, 
     actionLabel, 
     onAction, 
-    icon = <TableIcon className="w-12 h-12 text-gray-300" /> 
+    icon = <TableIcon className="w-12 h-12 text-gray-300 dark:text-gray-500" />
 }) => {
     return (
-        <div className="flex flex-col items-center justify-center p-12 text-center bg-gray-50/50 rounded-2xl border-2 border-dashed border-gray-200">
-            <div className="mb-4 p-4 bg-white rounded-full shadow-sm">
+        <div className="flex flex-col items-center justify-center p-12 text-center bg-gray-50/50 dark:bg-slate-900/50 rounded-2xl border-2 border-dashed border-gray-200 dark:border-slate-800 transition-colors">
+            <div className="mb-4 p-4 bg-white dark:bg-slate-800 rounded-full shadow-sm">
                 {icon}
             </div>
-            <h3 className="text-lg font-bold text-gray-800">{title}</h3>
-            <p className="text-sm text-gray-500 mt-1 max-w-xs mx-auto">{description}</p>
+            <h3 className="text-lg font-bold text-gray-800 dark:text-gray-100">{title}</h3>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 max-w-xs mx-auto">{description}</p>
             {actionLabel && onAction && (
                 <button 
                     onClick={onAction}
-                    className="mt-6 px-6 py-2 bg-white border border-gray-300 rounded-lg text-sm font-bold text-gray-700 hover:bg-gray-50 transition-all shadow-sm active:scale-95"
+                    className="mt-6 px-6 py-2 bg-white dark:bg-slate-800 border border-gray-300 dark:border-slate-700 rounded-lg text-sm font-bold text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-slate-700 transition-all shadow-sm active:scale-95"
                 >
                     {actionLabel}
                 </button>

--- a/enduser-ui-fe/src/pages/MarketingPage.tsx
+++ b/enduser-ui-fe/src/pages/MarketingPage.tsx
@@ -407,7 +407,7 @@ const MarketingPage: React.FC = () => {
                         <EmptyState 
                             title="No Leads Found" 
                             description="Enter a job title above to start scanning the market for potential customers."
-                            icon={<SearchIcon className="w-12 h-12 text-gray-300" />}
+                            icon={<SearchIcon className="w-12 h-12 text-gray-300 dark:text-gray-500" />}
                         />
                     )}
                 </div>


### PR DESCRIPTION
💡 What: Added dark mode support to the `EmptyState` component in `enduser-ui-fe` and updated its usage in `MarketingPage`.
🎯 Why: The previous implementation had hardcoded light-mode colors, making the empty state invisible or ugly in dark mode.
📸 Before/After: Verified with Playwright screenshot showing correct rendering in both light and dark modes.
♿ Accessibility: Improved contrast and ensured text/icons are visible in all themes. Added unit tests for the component.

---
*PR created automatically by Jules for task [17641042893826533070](https://jules.google.com/task/17641042893826533070) started by @info-vin*