### PR TITLE
feat(a11y): Add Skip to Content link for keyboard accessibility

### DIFF
--- a/enduser-ui-fe/src/components/layout/MainLayout.tsx
+++ b/enduser-ui-fe/src/components/layout/MainLayout.tsx
@@ -43,6 +43,9 @@ const MainLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 
     return (
         <div className="flex flex-col md:flex-row h-[100dvh] md:h-screen bg-background text-foreground overflow-hidden">
+            <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-background focus:text-foreground focus:ring-2 focus:ring-primary focus:outline-none">
+                Skip to content
+            </a>
              <nav className={`fixed inset-y-0 left-0 z-50 w-64 bg-card border-r border-border flex flex-col transform ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full'} transition-transform duration-300 ease-in-out md:relative md:translate-x-0`}>
                 <div className="p-4 border-b border-border flex justify-between items-center bg-card/50 backdrop-blur">
                     <Link to="/dashboard" className="flex items-center transition-transform hover:scale-105 active:scale-95">
@@ -145,7 +148,7 @@ const MainLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
                 </div>
             </nav>
             {isSidebarOpen && <div className="fixed inset-0 bg-black/50 z-40 md:hidden" onClick={() => setIsSidebarOpen(false)}></div>}
-            <main className={`flex-1 flex flex-col ${location.pathname === '/brand' ? 'h-screen overflow-hidden' : 'overflow-y-auto overscroll-contain'} bg-background pb-16 md:pb-0`}>
+            <main id="main-content" className={`flex-1 flex flex-col ${location.pathname === '/brand' ? 'h-screen overflow-hidden' : 'overflow-y-auto overscroll-contain'} bg-background pb-16 md:pb-0`}>
                 {/* Mobile Header */}
                 <header className="md:hidden flex items-center justify-between p-4 border-b border-border bg-background/80 backdrop-blur z-30 sticky top-0">
                     <LiveClock />

--- a/enduser-ui-fe/src/components/layout/PublicLayout.tsx
+++ b/enduser-ui-fe/src/components/layout/PublicLayout.tsx
@@ -29,6 +29,9 @@ const PublicLayout: React.FC = () => {
 
   return (
     <div className="min-h-screen flex flex-col bg-background text-foreground">
+      <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-background focus:text-foreground focus:ring-2 focus:ring-primary focus:outline-none">
+        Skip to content
+      </a>
       <header className="sticky top-0 z-40 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="container mx-auto flex h-14 max-w-screen-2xl items-center justify-between px-4">
           <Link to="/landing" className="mr-6 flex items-center space-x-2">
@@ -127,7 +130,7 @@ const PublicLayout: React.FC = () => {
         </div>
       )}
 
-      <main className="flex-1">
+      <main id="main-content" className="flex-1">
         <Outlet />
       </main>
       <footer className="py-6 md:px-8 md:py-0 border-t border-border">


### PR DESCRIPTION
Added a "Skip to content" link to both `MainLayout` and `PublicLayout` in `enduser-ui-fe`. This link is visually hidden by default but appears when focused (e.g., by pressing Tab), allowing keyboard users to skip repetitive navigation menus and jump directly to the main content area. This is a critical accessibility requirement (WCAG 2.4.1).

Verified implementation with a Playwright script and screenshot showing the focused link. Run existing unit tests to ensure no regressions.

---
*PR created automatically by Jules for task [1082621312292471728](https://jules.google.com/task/1082621312292471728) started by @info-vin*