### PR TITLE
🎨 Palette: Improve Select component accessibility

### DIFF
--- a/archon-ui-main/src/components/onboarding/ProviderStep.tsx
+++ b/archon-ui-main/src/components/onboarding/ProviderStep.tsx
@@ -89,6 +89,7 @@ export const ProviderStep = ({ onSaved, onSkip }: ProviderStepProps) => {
       <div>
         <Select
           label="Select AI Provider"
+          required
           value={provider}
           onChange={(e) => setProvider(e.target.value)}
           options={[
@@ -114,6 +115,7 @@ export const ProviderStep = ({ onSaved, onSkip }: ProviderStepProps) => {
           <div>
             <Input
               label="OpenAI API Key"
+              required
               type="password"
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}

--- a/archon-ui-main/src/components/ui/Select.test.tsx
+++ b/archon-ui-main/src/components/ui/Select.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Select } from './Select';
+
+describe('Select Component', () => {
+  it('renders with label and associates it with the select', () => {
+    const options = [
+      { value: 'option1', label: 'Option 1' },
+      { value: 'option2', label: 'Option 2' },
+    ];
+    render(<Select label="Test Select" options={options} />);
+
+    // This should initially fail because the label is not associated with the select
+    const select = screen.getByLabelText('Test Select');
+    expect(select).toBeInTheDocument();
+    expect(select).toHaveValue('option1');
+  });
+
+  it('renders required asterisk when required prop is true', () => {
+    const options = [{ value: '1', label: '1' }];
+    render(<Select label="Required Select" options={options} required />);
+
+    // Check for the asterisk
+    const asterisk = screen.getByText('*');
+    expect(asterisk).toBeInTheDocument();
+    expect(asterisk).toHaveClass('text-red-500');
+  });
+});

--- a/archon-ui-main/src/components/ui/Select.tsx
+++ b/archon-ui-main/src/components/ui/Select.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { accentColorMap } from '@/features/ui/primitives/accent-colors';
+
 interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
   accentColor?: 'purple' | 'green' | 'pink' | 'blue';
   label?: string;
@@ -8,30 +9,49 @@ interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
     label: string;
   }[];
 }
+
 export const Select: React.FC<SelectProps> = ({
   accentColor = 'purple',
   label,
   options,
   className = '',
+  id,
+  required,
   ...props
 }) => {
- 
-  return <div className="w-full">
-      {label && <label className="block text-gray-600 dark:text-zinc-400 text-sm mb-1.5">
+  const generatedId = useId();
+  const selectId = id || generatedId;
+
+  return (
+    <div className="w-full">
+      {label && (
+        <label
+          htmlFor={selectId}
+          className="block text-gray-600 dark:text-zinc-400 text-sm mb-1.5"
+        >
           {label}
-        </label>}
+          {required && <span className="text-red-500 ml-1" aria-hidden="true">*</span>}
+        </label>
+      )}
       <div className={`
         relative backdrop-blur-md bg-gradient-to-b dark:from-white/10 dark:to-black/30 from-white/80 to-white/60
         border dark:border-zinc-800/80 border-gray-200 rounded-md
         transition-all duration-200 ${accentColorMap[accentColor]}
       `}>
-        <select className={`
+        <select
+          id={selectId}
+          required={required}
+          className={`
             w-full bg-transparent text-gray-800 dark:text-white appearance-none px-3 py-2
             focus:outline-none ${className}
-          `} {...props}>
-          {options.map(option => <option key={option.value} value={option.value} className="bg-white dark:bg-zinc-900">
+          `}
+          {...props}
+        >
+          {options.map(option => (
+            <option key={option.value} value={option.value} className="bg-white dark:bg-zinc-900">
               {option.label}
-            </option>)}
+            </option>
+          ))}
         </select>
         <div className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none text-gray-500 dark:text-zinc-500">
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -39,5 +59,6 @@ export const Select: React.FC<SelectProps> = ({
           </svg>
         </div>
       </div>
-    </div>;
+    </div>
+  );
 };


### PR DESCRIPTION
*   💡 What: Added `useId` for automatic ID generation and label association in `archon-ui-main/src/components/ui/Select.tsx`. Added `required` prop support with a visual asterisk. Updated `ProviderStep.tsx` to use the `required` prop.
*   🎯 Why: The `Select` component was missing proper label association (no `htmlFor`), making it inaccessible to screen readers. Required fields were not visually distinguished.
*   📸 Before/After: Verified that the label is now clickable (focuses select) and required fields show a red asterisk.
*   ♿ Accessibility: Added `htmlFor`, unique IDs, and `aria-hidden` asterisk for required fields.

---
*PR created automatically by Jules for task [15300326347578362055](https://jules.google.com/task/15300326347578362055) started by @info-vin*