### PR TITLE
🎨 Palette: Add accessible labels to Dashboard view mode buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-03 - Accessible Icon-Only Buttons
+**Learning:** Adding `aria-label` and `title` to icon-only buttons drastically improves accessibility for screen readers and provides helpful tooltips for sighted users. Grouping them with `role="group"` and `aria-label="View mode"` provides better context.
+**Action:** Always check icon-only buttons for missing accessible labels and apply `aria-label` and `title` attributes. For grouped controls, use `role="group"`. When unit testing these in `enduser-ui-fe`, remember to wrap them in `<AuthProvider>` and properly mock the api and supabase client to avoid render failures.

--- a/enduser-ui-fe/src/pages/DashboardPage.tsx
+++ b/enduser-ui-fe/src/pages/DashboardPage.tsx
@@ -531,11 +531,11 @@ const DashboardPage: React.FC = () => {
           </div>
 
           {/* View Mode Buttons */}
-          <div className="flex items-center bg-card border border-border rounded-md p-1">
-            <button onClick={() => setViewMode('list')} className={`p-1.5 ${viewMode === 'list' ? 'bg-background' : ''}`}><ListIcon className="h-5 w-5" /></button>
-            <button onClick={() => setViewMode('table')} className={`p-1.5 ${viewMode === 'table' ? 'bg-background' : ''}`}><TableIcon className="h-5 w-5" /></button>
-            <button onClick={() => setViewMode('kanban')} className={`p-1.5 ${viewMode === 'kanban' ? 'bg-background' : ''}`}><KanbanIcon className="h-5 w-5" /></button>
-            <button onClick={() => setViewMode('gantt')} className={`p-1.5 ${viewMode === 'gantt' ? 'bg-background' : ''}`}><GanttChartIcon className="h-5 w-5" /></button>
+          <div className="flex items-center bg-card border border-border rounded-md p-1" role="group" aria-label="View mode">
+            <button onClick={() => setViewMode('list')} aria-label="List view" title="List view" aria-pressed={viewMode === 'list'} className={`p-1.5 rounded-md transition-colors ${viewMode === 'list' ? 'bg-background shadow-sm' : 'hover:bg-background/50'}`}><ListIcon className="h-5 w-5" /></button>
+            <button onClick={() => setViewMode('table')} aria-label="Table view" title="Table view" aria-pressed={viewMode === 'table'} className={`p-1.5 rounded-md transition-colors ${viewMode === 'table' ? 'bg-background shadow-sm' : 'hover:bg-background/50'}`}><TableIcon className="h-5 w-5" /></button>
+            <button onClick={() => setViewMode('kanban')} aria-label="Kanban view" title="Kanban view" aria-pressed={viewMode === 'kanban'} className={`p-1.5 rounded-md transition-colors ${viewMode === 'kanban' ? 'bg-background shadow-sm' : 'hover:bg-background/50'}`}><KanbanIcon className="h-5 w-5" /></button>
+            <button onClick={() => setViewMode('gantt')} aria-label="Gantt chart view" title="Gantt chart view" aria-pressed={viewMode === 'gantt'} className={`p-1.5 rounded-md transition-colors ${viewMode === 'gantt' ? 'bg-background shadow-sm' : 'hover:bg-background/50'}`}><GanttChartIcon className="h-5 w-5" /></button>
           </div>
 
           {/* New Task Button */}

--- a/enduser-ui-fe/src/pages/DashboardPageA11y.test.tsx
+++ b/enduser-ui-fe/src/pages/DashboardPageA11y.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import DashboardPage from './DashboardPage';
+import { AuthProvider } from '../hooks/useAuth';
+
+// Mock the api to avoid network calls during render
+vi.mock('../services/api', () => ({
+  api: {
+    getProjects: vi.fn().mockResolvedValue([]),
+    getTasks: vi.fn().mockResolvedValue([]),
+    getRecentActivity: vi.fn().mockResolvedValue([]),
+    getCurrentUser: vi.fn().mockResolvedValue({ id: '1', email: 'test@example.com', role: 'user' }),
+    getAssignableUsers: vi.fn().mockResolvedValue([])
+  },
+  supabase: null
+}));
+
+describe('DashboardPage Accessibility', () => {
+  it('renders view mode buttons with proper aria labels', async () => {
+    render(
+      <AuthProvider>
+        <BrowserRouter>
+          <DashboardPage />
+        </BrowserRouter>
+      </AuthProvider>
+    );
+
+    // Verify the group
+    await waitFor(() => {
+        const viewModeGroup = screen.getByRole('group', { name: 'View mode' });
+        expect(viewModeGroup).toBeInTheDocument();
+    });
+
+    // Verify buttons have aria-label and titles
+    const listBtn = screen.getByRole('button', { name: 'List view' });
+    expect(listBtn).toHaveAttribute('title', 'List view');
+    expect(listBtn).toHaveAttribute('aria-pressed', 'true');
+
+    const tableBtn = screen.getByRole('button', { name: 'Table view' });
+    expect(tableBtn).toHaveAttribute('title', 'Table view');
+    expect(tableBtn).toHaveAttribute('aria-pressed', 'false');
+
+    const kanbanBtn = screen.getByRole('button', { name: 'Kanban view' });
+    expect(kanbanBtn).toHaveAttribute('title', 'Kanban view');
+    expect(kanbanBtn).toHaveAttribute('aria-pressed', 'false');
+
+    const ganttBtn = screen.getByRole('button', { name: 'Gantt chart view' });
+    expect(ganttBtn).toHaveAttribute('title', 'Gantt chart view');
+    expect(ganttBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+});


### PR DESCRIPTION
🎨 Palette: Add accessible labels to Dashboard view mode buttons

💡 What:
- Added `role="group"` and `aria-label="View mode"` to the container for the view mode toggle buttons.
- Added `aria-label`, `title`, and `aria-pressed` to the List, Table, Kanban, and Gantt chart icon buttons.
- Improved the hover and selected visual states for these buttons with `transition-colors`, `hover:bg-background/50` and `shadow-sm`.
- Wrote an accessibility unit test (`DashboardPageA11y.test.tsx`) to enforce these labels.

🎯 Why:
- Icon-only buttons must have text equivalents so screen readers can announce their purpose.
- Adding `title` attributes acts as a tooltip to assist all users in understanding what the icons mean.
- Using `aria-pressed` clearly conveys which view is currently active.
- Improving the visual state on hover adds to the micro-interaction polish.

---
*PR created automatically by Jules for task [1148141728518446162](https://jules.google.com/task/1148141728518446162) started by @info-vin*