### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/enduser-ui-fe/src/features/manager/components/OpLoadPanel.tsx
+++ b/enduser-ui-fe/src/features/manager/components/OpLoadPanel.tsx
@@ -189,7 +189,7 @@ export const OpLoadPanel: React.FC<OpLoadPanelProps> = ({
                                             <span className="text-[10px] text-gray-400 font-bold uppercase">{selectedContent.author_name || selectedContent.authorName}</span>
                                         </div>
                                     </div>
-                                    <button onClick={() => setSelectedContent(null)} className="p-2 hover:bg-gray-200 rounded-full transition-colors"><XIcon className="w-4 h-4" /></button>
+                                    <button onClick={() => setSelectedContent(null)} className="p-2 hover:bg-gray-200 rounded-full transition-colors" aria-label="Close content preview"><XIcon className="w-4 h-4" /></button>
                                 </div>
 
                                 <div className="prose prose-sm dark:prose-invert max-w-none mb-8 bg-white dark:bg-slate-950 p-6 rounded-xl border border-gray-100 dark:border-slate-800 shadow-sm overflow-hidden">
@@ -284,6 +284,7 @@ export const OpLoadPanel: React.FC<OpLoadPanelProps> = ({
                                         onClick={() => handleViewDiff(prop)}
                                         className="p-4 bg-gray-50 dark:bg-slate-800 text-gray-600 dark:text-slate-400 rounded-2xl hover:bg-gray-100 dark:hover:bg-slate-700 transition-all border border-gray-100 dark:border-slate-700"
                                         title="Inspect Code Difference"
+                                        aria-label="Inspect Code Difference"
                                     >
                                         <SearchIcon className="w-5 h-5" />
                                     </button>

--- a/enduser-ui-fe/src/pages/TeamManagementPage.tsx
+++ b/enduser-ui-fe/src/pages/TeamManagementPage.tsx
@@ -194,7 +194,7 @@ const TeamManagementPage: React.FC = () => {
                                         <p className="text-xs text-gray-500">Real-time Human vs Machine Resource Audit (Last 7 Days)</p>
                                     </div>
                                 </div>
-                                <button onClick={() => setShowTokenDetails(false)} className="p-2 hover:bg-gray-200 rounded-full transition-colors"><XIcon className="w-5 h-5" /></button>
+                                <button onClick={() => setShowTokenDetails(false)} className="p-2 hover:bg-gray-200 rounded-full transition-colors" aria-label="Close token details"><XIcon className="w-5 h-5" /></button>
                             </div>
                             
                             <div className="flex-1 overflow-y-auto p-0">
@@ -231,7 +231,7 @@ const TeamManagementPage: React.FC = () => {
                                         <p className="text-[10px] text-gray-500">Phase 4.6.1 Standard Operating Procedure</p>
                                     </div>
                                 </div>
-                                <button onClick={() => setShowSopModal(false)} className="p-2 hover:bg-gray-200 rounded-full transition-colors"><XIcon className="w-5 h-5" /></button>
+                                <button onClick={() => setShowSopModal(false)} className="p-2 hover:bg-gray-200 rounded-full transition-colors" aria-label="Close SOP modal"><XIcon className="w-5 h-5" /></button>
                             </div>
                             
                             <div className="flex-1 overflow-y-auto p-6 md:p-8 bg-gray-50">
@@ -288,7 +288,7 @@ const ActivityLogModal: React.FC<{ member: Employee; onClose: () => void }> = ({
                             <p className="text-xs text-gray-500">Recent Assignments & Tasks</p>
                         </div>
                     </div>
-                    <button onClick={onClose} className="p-2 hover:bg-gray-200 rounded-full transition-colors"><XIcon className="w-5 h-5" /></button>
+                    <button onClick={onClose} className="p-2 hover:bg-gray-200 rounded-full transition-colors" aria-label="Close activity log"><XIcon className="w-5 h-5" /></button>
                 </div>
                 
                 <div className="flex-1 overflow-y-auto p-6">


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to multiple icon-only buttons across the application.
🎯 **Why:** To improve accessibility for screen reader users by providing descriptive labels for buttons that previously only contained icons (e.g., closing modals, inspecting code differences).
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now announce the purpose of these buttons (e.g., "Close content preview", "Inspect Code Difference", "Close token details", "Close SOP modal", "Close activity log") instead of remaining silent or reading "button".

---
*PR created automatically by Jules for task [14526100873568750059](https://jules.google.com/task/14526100873568750059) started by @info-vin*