### PR TITLE
🎨 Palette: Improve Accessibility on Icon-Only Buttons

### DIFF
--- a/enduser-ui-fe/src/features/marketing/components/LeadsCardStack.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/LeadsCardStack.tsx
@@ -114,7 +114,7 @@ const HistoryDrawer = ({ lead, onClose }: { lead: Lead, onClose: () => void }) =
             >
                 <div className="flex justify-between items-center mb-6">
                     <h3 className="text-lg font-bold">Activity Timeline</h3>
-                    <button onClick={onClose}><XIcon className="w-5 h-5 text-gray-400" /></button>
+                    <button onClick={onClose} aria-label="Close timeline" className="focus-visible:ring-2 focus-visible:ring-indigo-500 rounded-full outline-none"><XIcon className="w-5 h-5 text-gray-400" /></button>
                 </div>
                 <LeadsTimeline events={mockEvents} />
             </div>

--- a/enduser-ui-fe/src/features/marketing/components/MarketingJobSearch.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/MarketingJobSearch.tsx
@@ -54,7 +54,7 @@ export const MarketingJobSearch: React.FC<MarketingJobSearchProps> = ({
           {error && (
             <div className="bg-red-50 text-red-700 p-4 rounded-lg border border-red-100 flex justify-between items-center">
               <span>{error}</span>
-              <button onClick={() => setError(null)} className="p-1 hover:bg-red-100 rounded-full transition-colors"><XIcon className="w-4 h-4" /></button>
+              <button onClick={() => setError(null)} aria-label="Dismiss error" className="p-1 hover:bg-red-100 rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-red-500 outline-none"><XIcon className="w-4 h-4" /></button>
             </div>
           )}
           

--- a/enduser-ui-fe/src/features/marketing/components/VisitLogModal.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/VisitLogModal.tsx
@@ -129,7 +129,7 @@ export const VisitLogModal: React.FC<VisitLogModalProps> = ({ onClose, onSuccess
             <div className="bg-white rounded-t-2xl sm:rounded-xl shadow-xl w-full max-w-md p-6 animate-in slide-in-from-bottom-10 sm:slide-in-from-bottom-0 sm:zoom-in-95 duration-200">
                 <div className="flex justify-between items-center mb-6">
                     <h3 className="text-xl font-bold">New Visit Log</h3>
-                    <button onClick={onClose}><XIcon className="w-6 h-6 text-gray-400" /></button>
+                    <button onClick={onClose} aria-label="Close modal" className="focus-visible:ring-2 focus-visible:ring-indigo-500 rounded-full outline-none"><XIcon className="w-6 h-6 text-gray-400" /></button>
                 </div>
 
                 {step === 'type' && (


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `focus-visible` styles to icon-only `XIcon` close/dismiss buttons in `VisitLogModal.tsx`, `LeadsCardStack.tsx`, and `MarketingJobSearch.tsx`.

🎯 **Why:** To improve screen reader accessibility and keyboard navigation for users. Screen readers will now announce the button's purpose instead of just the word "button" or reading the SVG tag out loud. Keyboard users will now clearly see when the button receives focus.

📸 **Before/After:** See attached Playwright verification snapshot of the focus state.

♿ **Accessibility:** Improvements target WCAG success criteria for Name, Role, Value (4.1.2) and Focus Visible (2.4.7).

---
*PR created automatically by Jules for task [16184690318825116916](https://jules.google.com/task/16184690318825116916) started by @info-vin*