### PR TITLE
🎨 Palette: Add missing ARIA labels to icon-only close buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-03-03 - Accessible Icon-Only Buttons
 **Learning:** Adding `aria-label` and `title` to icon-only buttons drastically improves accessibility for screen readers and provides helpful tooltips for sighted users. Grouping them with `role="group"` and `aria-label="View mode"` provides better context.
 **Action:** Always check icon-only buttons for missing accessible labels and apply `aria-label` and `title` attributes. For grouped controls, use `role="group"`. When unit testing these in `enduser-ui-fe`, remember to wrap them in `<AuthProvider>` and properly mock the api and supabase client to avoid render failures.
+
+## 2025-03-03 - Missing ARIA Labels on Close Modals
+**Learning:** Icon-only close buttons (`XIcon`) across various feature components (`ContentWorkbench`, `ManagerNexus`, `LeadsCardStack`, `BrandWorkbenchView`) frequently lack `aria-label` attributes, causing them to be announced simply as "button" by screen readers.
+**Action:** When implementing modal or panel close actions using `XIcon` or similar icon-only buttons, always explicitly add an `aria-label` attribute (e.g., `aria-label="Close modal"` or a more descriptive label like `aria-label="Close AI Command Center"`).

--- a/enduser-ui-fe/src/features/marketing/components/BrandWorkbenchView.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/BrandWorkbenchView.tsx
@@ -93,6 +93,7 @@ export const BrandWorkbenchView: React.FC<BrandWorkbenchViewProps> = ({
             <button 
                 onClick={() => setIsSidebarOpen(!isSidebarOpen)}
                 className="absolute left-0 bottom-10 z-30 bg-indigo-600 text-white p-2 rounded-r-lg shadow-lg hover:bg-indigo-700 transition-all transform hover:scale-110 active:scale-95"
+                aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
             >
                 {isSidebarOpen ? <XIcon className="w-4 h-4" /> : <LayoutIcon className="w-4 h-4" />}
             </button>

--- a/enduser-ui-fe/src/features/marketing/components/ContentWorkbench.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/ContentWorkbench.tsx
@@ -379,7 +379,7 @@ export const ContentWorkbench: React.FC<ContentWorkbenchProps> = ({
                     <p className="text-[9px] font-bold text-slate-400 uppercase tracking-tighter">Unified Prompt & Logic Console</p>
                   </div>
                 </div>
-                <button onClick={() => setPromptCenterOpen(false)} className="p-2 hover:bg-slate-200 dark:hover:bg-slate-800 rounded-full transition-colors">
+                <button onClick={() => setPromptCenterOpen(false)} className="p-2 hover:bg-slate-200 dark:hover:bg-slate-800 rounded-full transition-colors" aria-label="Close AI Command Center">
                   <XIcon className="w-5 h-5 text-slate-400" />
                 </button>
               </div>

--- a/enduser-ui-fe/src/features/marketing/components/LeadsCardStack.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/LeadsCardStack.tsx
@@ -67,7 +67,7 @@ const PitchDrawer = ({ lead, onClose }: { lead: Lead, onClose: () => void }) => 
                         </div>
                         <h3 className="text-lg font-bold">{lead.pitch_content ? 'Saved Pitch' : 'AI Pitch Generator'}</h3>
                     </div>
-                    <button onClick={onClose} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+                    <button onClick={onClose} className="p-2 hover:bg-gray-100 rounded-full transition-colors" aria-label="Close Pitch Generator">
                         <XIcon className="w-5 h-5 text-gray-500" />
                     </button>
                 </div>

--- a/enduser-ui-fe/src/pages/ManagerNexus.tsx
+++ b/enduser-ui-fe/src/pages/ManagerNexus.tsx
@@ -489,7 +489,7 @@ export const ManagerNexus: React.FC = () => {
                                     </div>
                                     <h2 className="text-lg font-black text-gray-900 dark:text-white uppercase tracking-tight">Nexus Metrics Spec</h2>
                                 </div>
-                                <button onClick={() => setIsSpecOpen(false)} className="p-2 hover:bg-gray-200/50 dark:hover:bg-slate-800 rounded-full transition-colors text-gray-400">
+                                <button onClick={() => setIsSpecOpen(false)} className="p-2 hover:bg-gray-200/50 dark:hover:bg-slate-800 rounded-full transition-colors text-gray-400" aria-label="Close Nexus Metrics Spec">
                                     <XIcon className="w-6 h-6" />
                                 </button>
                             </div>


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to icon-only close buttons (`XIcon` and `LayoutIcon`) across multiple feature components. 
🎯 **Why:** To improve accessibility for screen reader users, who would otherwise just hear "button" for these controls, making the UI harder to navigate.
♿ **Accessibility:** Fixes a critical accessibility anti-pattern.
📸 **Verification:** Confirmed the changes do not break styling and properly emit standard HTML. Validated via `pnpm test:unit` in `enduser-ui-fe` which passed all 45 tests.

---
*PR created automatically by Jules for task [4810498193540923947](https://jules.google.com/task/4810498193540923947) started by @info-vin*