### PR TITLE
🎨 Palette: Add aria-label to error dismiss button in MarketingJobSearch

### DIFF
--- a/enduser-ui-fe/src/features/marketing/components/MarketingJobSearch.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/MarketingJobSearch.tsx
@@ -54,7 +54,7 @@ export const MarketingJobSearch: React.FC<MarketingJobSearchProps> = ({
           {error && (
             <div className="bg-red-50 text-red-700 p-4 rounded-lg border border-red-100 flex justify-between items-center">
               <span>{error}</span>
-              <button onClick={() => setError(null)} className="p-1 hover:bg-red-100 rounded-full transition-colors outline-none"><XIcon className="w-4 h-4" /></button>
+              <button onClick={() => setError(null)} className="p-1 hover:bg-red-100 rounded-full transition-colors outline-none" aria-label="Dismiss error"><XIcon className="w-4 h-4" /></button>
             </div>
           )}
           


### PR DESCRIPTION
Added `aria-label="Dismiss error"` to the icon-only close button for the error message in `MarketingJobSearch.tsx` to improve screen reader accessibility. This small touch of accessibility ensures that users relying on screen readers can understand the purpose of this button.

---
*PR created automatically by Jules for task [6924774851748994094](https://jules.google.com/task/6924774851748994094) started by @info-vin*