### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/enduser-ui-fe/src/components/KnowledgeSelector.tsx
+++ b/enduser-ui-fe/src/components/KnowledgeSelector.tsx
@@ -89,6 +89,8 @@ export const KnowledgeSelector: React.FC<KnowledgeSelectorProps> = ({
               onClick={() => toggleItem(item.source_id)}
               className="hover:text-destructive transition-colors"
               disabled={disabled}
+              aria-label="Remove item"
+              title="Remove item"
             >
               <XIcon className="w-3 h-3" />
             </button>

--- a/enduser-ui-fe/src/features/admin/components/AdminCrawlerConfig.tsx
+++ b/enduser-ui-fe/src/features/admin/components/AdminCrawlerConfig.tsx
@@ -100,7 +100,7 @@ export const AdminCrawlerConfig: React.FC = () => {
                                     <td className="px-4 py-3 font-mono text-xs text-blue-600 dark:text-blue-400 break-all">{t.target_url}</td>
                                     <td className="px-4 py-3 text-muted-foreground">{t.description || '-'}</td>
                                     <td className="px-4 py-3 text-center font-bold">{t.max_depth}</td>
-                                    <td className="px-4 py-3 text-right"><button onClick={() => deleteTarget(t.id)} className="p-1.5 text-red-500 hover:bg-red-500/10 rounded-lg transition-all"><XIcon className="w-4 h-4" /></button></td>
+                                    <td className="px-4 py-3 text-right"><button onClick={() => deleteTarget(t.id)} className="p-1.5 text-red-500 hover:bg-red-500/10 rounded-lg transition-all" aria-label="Delete target" title="Delete target"><XIcon className="w-4 h-4" /></button></td>
                                 </tr>
                             ))}
                         </tbody>


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to `XIcon` icon-only buttons in `AdminCrawlerConfig` and `KnowledgeSelector` components.

🎯 Why: Icon-only buttons without an accessible name are completely invisible/useless to screen readers (they just hear "button"). Adding these attributes improves accessibility drastically and also provides a helpful tooltip on hover for all users.

📸 Before/After: Verified visual layout remains completely unaffected via Playwright screenshot.

♿ Accessibility: Improved screen reader support by providing explicit accessible names for the "Delete target" and "Remove item" actions.

---
*PR created automatically by Jules for task [15529306691847695861](https://jules.google.com/task/15529306691847695861) started by @info-vin*