### PR TITLE
🎨 Palette: Add accessible aria-label to Ollama Modal close button

### DIFF
--- a/archon-ui-main/PR_DESCRIPTION.md
+++ b/archon-ui-main/PR_DESCRIPTION.md
@@ -1,0 +1,11 @@
+💡 **What:**
+Added `aria-label` and `title` attributes ("Close modal") to the `<X>` icon-only close button in `OllamaModelSelectionModal.tsx`.
+
+🎯 **Why:**
+Icon-only buttons without accessible names cannot be interpreted by screen readers, making it difficult or impossible for visually impaired users to know how to close the modal. Adding a `title` attribute also provides a helpful tooltip for mouse users, clarifying the button's action before they click.
+
+📸 **Before/After:**
+*(See attached verification snapshot from Playwright for the visual state - visually identical, but semantically accessible).*
+
+♿ **Accessibility:**
+Fixes a critical WCAG gap (Missing ARIA label / Name, Role, Value) by explicitly naming the interactive element "Close modal".

--- a/archon-ui-main/src/features/rag-settings/components/OllamaModelSelectionModal.tsx
+++ b/archon-ui-main/src/features/rag-settings/components/OllamaModelSelectionModal.tsx
@@ -172,7 +172,7 @@ export const OllamaModelSelectionModal: React.FC<OllamaModelSelectionModalProps>
           <div><h2 className="text-xl font-semibold text-white flex items-center"><Zap className="w-5 h-5 text-blue-400 mr-2" />Select Ollama Model</h2><p className="text-sm text-gray-400 mt-1">Choose model for {modelType} from {selectedInstanceUrl}</p></div>
           <div className="flex items-center gap-2">
             <Button variant="outline" size="sm" onClick={refreshModels} disabled={refreshing} className="text-blue-400 border-blue-400"><RotateCcw className={`w-4 h-4 mr-1 ${refreshing ? 'animate-spin' : ''}`} />Refresh</Button>
-            <button onClick={onClose} className="text-gray-400 hover:text-white"><X className="w-6 h-6" /></button>
+            <button onClick={onClose} aria-label="Close modal" title="Close modal" className="text-gray-400 hover:text-white"><X className="w-6 h-6" /></button>
           </div>
         </div>
         <div className="p-6 border-b border-gray-700">


### PR DESCRIPTION
💡 **What:**
Added `aria-label` and `title` attributes ("Close modal") to the `<X>` icon-only close button in `OllamaModelSelectionModal.tsx`.

🎯 **Why:**
Icon-only buttons without accessible names cannot be interpreted by screen readers, making it difficult or impossible for visually impaired users to know how to close the modal. Adding a `title` attribute also provides a helpful tooltip for mouse users, clarifying the button's action before they click.

📸 **Before/After:**
*(See attached verification snapshot from Playwright for the visual state - visually identical, but semantically accessible).*

♿ **Accessibility:**
Fixes a critical WCAG gap (Missing ARIA label / Name, Role, Value) by explicitly naming the interactive element "Close modal".

---
*PR created automatically by Jules for task [14810679368605364320](https://jules.google.com/task/14810679368605364320) started by @info-vin*