### PR TITLE
Refactor: Extract ManagerNexus components into nexus directory

### DIFF
--- a/enduser-ui-fe/src/features/manager/components/nexus/EthicsAuditPanel.tsx
+++ b/enduser-ui-fe/src/features/manager/components/nexus/EthicsAuditPanel.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { ShieldCheckIcon, ZapIcon, FileTextIcon, CheckCircleIcon } from '../../../../components/Icons';
+
+export interface EthicsAuditPanelProps {
+    ethicsAudit: any;
+    handleDispatch: (id: string) => void;
+    handleApprovePrompt: (id: string) => void;
+    processingId: string | null;
+}
+
+export const EthicsAuditPanel: React.FC<EthicsAuditPanelProps> = ({
+    ethicsAudit,
+    handleDispatch,
+    handleApprovePrompt,
+    processingId
+}) => {
+    const handleViewDiff = (item: any) => {
+        try {
+            if (!item) return;
+            let contentData = item.content;
+            if (typeof item.content === 'string') {
+                try {
+                    contentData = JSON.parse(item.content);
+                } catch (e) {
+                    contentData = { raw: item.content };
+                }
+            }
+            const summary = item.change_summary || "Strategic Prompt Update";
+            const field = item.field_name || "Prompt Config";
+            const author = item.created_by || "System";
+            const displayStr = typeof contentData === 'string' ? contentData : JSON.stringify(contentData, null, 2);
+
+            alert(
+                `[ AUDIT VIEW: PROMPT CHANGE ]\n` +
+                `----------------------------------\n` +
+                `Target: ${item.document_id}\n` +
+                `Author: ${author}\n` +
+                `Field:  ${field}\n` +
+                `Summary: ${summary}\n\n` +
+                `NEW CONTENT PREVIEW:\n` +
+                `${displayStr.slice(0, 400)}${displayStr.length > 400 ? '...' : ''}`
+            );
+        } catch (err) {
+            console.error("ViewDiff Failed:", err);
+            alert("Unable to preview this change. The data format might be incompatible.");
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <div className="bg-indigo-50/30 border border-indigo-100 rounded-3xl p-6">
+                <h4 className="text-xs font-black text-indigo-900 uppercase tracking-widest mb-4 flex items-center gap-2">
+                    <ZapIcon className="w-3 h-3" /> Actionable Safety Queue ({ethicsAudit?.total_pending || 0})
+                </h4>
+
+                <div className="space-y-4">
+                    {/* 1. Ethics Violations (Sentinel) */}
+                    {ethicsAudit?.violations.map((v: any) => (
+                        <div key={v.id} className="bg-white border border-red-100 p-4 rounded-2xl flex items-center justify-between shadow-sm hover:shadow-md transition-all">
+                            <div className="flex items-center gap-4">
+                                <div className="bg-red-50 p-3 rounded-xl text-red-600">
+                                    <ShieldCheckIcon className="w-5 h-5" />
+                                </div>
+                                <div>
+                                    <span className="text-[10px] font-black px-2 py-0.5 bg-red-100 text-red-700 rounded uppercase">Safety Intercept</span>
+                                    <h5 className="font-bold text-gray-800 text-sm mt-1">{v.event_type}: {v.description}</h5>
+                                    <p className="text-[10px] text-gray-400 font-mono mt-0.5">Attempted Input: {v.raw_input?.slice(0, 50)}...</p>
+                                </div>
+                            </div>
+                            <button
+                                onClick={() => handleDispatch(v.id)}
+                                className="px-4 py-2 bg-red-600 text-white rounded-xl text-[10px] font-black hover:bg-red-700 transition-all"
+                            >
+                                DISPATCH INVESTIGATION
+                            </button>
+                        </div>
+                    ))}
+
+                    {/* 2. Prompt Changes (Librarian) */}
+                    {ethicsAudit?.pending_versions.map((p: any) => (
+                        <div key={p.id} className="bg-white border border-amber-100 p-4 rounded-2xl flex items-center justify-between shadow-sm hover:shadow-md transition-all">
+                            <div className="flex items-center gap-4">
+                                <div className="bg-amber-50 p-3 rounded-xl text-amber-600">
+                                    <FileTextIcon className="w-5 h-5" />
+                                </div>
+                                <div>
+                                    <span className="text-[10px] font-black px-2 py-0.5 bg-amber-100 text-amber-700 rounded uppercase">Prompt Change</span>
+                                    <h5 className="font-bold text-gray-800 text-sm mt-1">{p.document_id} (v{p.version_number})</h5>
+                                    <p className="text-[10px] text-gray-400 font-mono mt-0.5">Changed by {p.created_by} | {p.change_summary}</p>
+                                </div>
+                            </div>
+                            <div className="flex gap-2">
+                                <button
+                                    onClick={() => handleViewDiff(p)}
+                                    className="px-4 py-2 bg-slate-100 text-slate-600 rounded-xl text-[10px] font-black hover:bg-slate-200"
+                                >
+                                    VIEW DIFF
+                                </button>
+                                <button
+                                    onClick={() => handleApprovePrompt(p.id)}
+                                    disabled={processingId === p.id}
+                                    className="px-4 py-2 bg-indigo-600 text-white rounded-xl text-[10px] font-black hover:bg-indigo-700"
+                                >
+                                    {processingId === p.id ? '...' : 'APPROVE'}
+                                </button>
+                            </div>
+                        </div>
+                    ))}
+
+                    {ethicsAudit?.total_pending === 0 && (
+                        <div className="py-12 flex flex-col items-center justify-center text-center text-green-600 opacity-60">
+                            <CheckCircleIcon className="w-12 h-12 mb-2" />
+                            <p className="text-sm font-black uppercase tracking-widest">Compliance Nominal</p>
+                            <p className="text-[10px]">No unauthorized prompt changes or safety leaks detected.</p>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/enduser-ui-fe/src/features/manager/components/nexus/NexusEmptyState.tsx
+++ b/enduser-ui-fe/src/features/manager/components/nexus/NexusEmptyState.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { ActivityIcon } from '../../../../components/Icons';
+
+export const NexusEmptyState: React.FC = () => {
+    return (
+        <div className="p-12 text-center text-gray-400 bg-white rounded-3xl border border-dashed border-gray-200">
+            <ActivityIcon className="w-12 h-12 mx-auto mb-4 opacity-20" />
+            <p>Select a metric above to view details.</p>
+        </div>
+    );
+};

--- a/enduser-ui-fe/src/features/manager/components/nexus/NexusFooter.tsx
+++ b/enduser-ui-fe/src/features/manager/components/nexus/NexusFooter.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+export const NexusFooter: React.FC = () => {
+    return (
+        <footer className="mt-12 pt-8 border-t border-gray-200 text-xs text-gray-400 grid grid-cols-1 md:grid-cols-3 gap-8">
+            <div>
+                <h5 className="font-bold text-gray-500 uppercase tracking-widest mb-2">Metrics Definition</h5>
+                <ul className="space-y-1">
+                    <li>• <strong className="text-gray-600">Reliability:</strong> 6-month strategic SLA attainment (Bi-weekly).</li>
+                    <li>• <strong className="text-gray-600">ROI:</strong> 60-day intelligence yield (Pages Saved / URLs Scanned).</li>
+                </ul>
+            </div>
+            <div>
+                 <h5 className="font-bold text-gray-500 uppercase tracking-widest mb-2">Color Codes</h5>
+                 <ul className="space-y-1">
+                    <li className="flex items-center gap-2"><div className="w-2 h-2 bg-green-500 rounded-full"></div> Optimal Range</li>
+                    <li className="flex items-center gap-2"><div className="w-2 h-2 bg-amber-500 rounded-full"></div> Warning / Action Needed</li>
+                    <li className="flex items-center gap-2"><div className="w-2 h-2 bg-red-500 rounded-full"></div> Critical Exception</li>
+                 </ul>
+            </div>
+            <div>
+                <h5 className="font-bold text-gray-500 uppercase tracking-widest mb-2">System Info</h5>
+                <p>ManagerNexus v7.1 | Build 2026.02.12</p>
+                <p className="mt-1">© Archon Intelligence Systems</p>
+            </div>
+        </footer>
+    );
+};

--- a/enduser-ui-fe/src/features/manager/components/nexus/NexusHUD.tsx
+++ b/enduser-ui-fe/src/features/manager/components/nexus/NexusHUD.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { HUDCard } from '../HUDCard';
+import { MetricCategory } from '../../hooks/useManagerNexusStats';
+
+export interface NexusHUDProps {
+    activeMetric: MetricCategory;
+    setActiveMetric: (metric: MetricCategory) => void;
+    loading: boolean;
+    overview: any;
+    approvals: any;
+    alerts: any;
+    team: any;
+    ethicsAudit: any;
+    collabSynergy: any;
+    knowledgeRoi: any;
+    slaReliability: any;
+}
+
+export const NexusHUD: React.FC<NexusHUDProps> = ({
+    activeMetric,
+    setActiveMetric,
+    loading,
+    overview,
+    approvals,
+    alerts,
+    team,
+    ethicsAudit,
+    collabSynergy,
+    knowledgeRoi,
+    slaReliability
+}) => {
+    return (
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+            <HUDCard
+                id="integrity" label="Integrity"
+                value={overview?.integrity_score !== undefined ? `${overview.integrity_score}%` : "..."}
+                sub="System Health"
+                active={activeMetric === 'integrity'}
+                status={overview?.status === 'healthy' ? 'good' : 'bad'}
+                onClick={setActiveMetric}
+                tooltip="RAG Vector DB Health"
+                loading={loading}
+            />
+            <HUDCard
+                id="resources" label="Resources"
+                value={`$${(overview?.cost_24h || 0).toFixed(2)}`}
+                sub="Monthly Cap"
+                active={activeMetric === 'resources'}
+                status="neutral"
+                onClick={setActiveMetric}
+                tooltip="Token Usage & Cost vs Budget"
+                loading={loading}
+            />
+            <HUDCard
+                id="op_load" label="Op Load"
+                value={`${approvals.blogs.length + approvals.leads.length} Items`}
+                sub="Decision Queue"
+                active={activeMetric === 'op_load'}
+                status={approvals.blogs.length > 0 ? "warning" : "good"}
+                onClick={setActiveMetric}
+                tooltip="Pending Approvals & Reviews"
+                loading={loading}
+            />
+            <HUDCard
+                id="sent_risks" label="Sent Risks"
+                value={`${alerts.length} Alerts`}
+                sub="Exception Radar"
+                active={activeMetric === 'sent_risks'}
+                status={alerts.length > 0 ? "bad" : "good"}
+                onClick={setActiveMetric}
+                tooltip="Sentinel Generated Alerts"
+                loading={loading}
+            />
+            <HUDCard
+                id="active_force" label="Act Force"
+                value={`${team.filter((m: any) => m.status === 'active').length} Online`}
+                sub="Roster Status"
+                active={activeMetric === 'active_force'}
+                status="good"
+                onClick={setActiveMetric}
+                tooltip="Team & Agent Availability"
+                loading={loading}
+            />
+            {/* Secondary Metrics Row */}
+            <HUDCard
+                id="ethics" label="Ethics"
+                value={ethicsAudit?.total_pending > 0 ? `${ethicsAudit.total_pending} Actions` : "Secure"}
+                sub={ethicsAudit?.total_pending > 0 ? `${ethicsAudit.violations.length} Risks | ${ethicsAudit.pending_versions.length} Changes` : "System Nominal"}
+                active={activeMetric === 'ethics'}
+                status={ethicsAudit?.total_pending > 0 ? 'bad' : 'good'}
+                onClick={setActiveMetric}
+                tooltip="Safety violations & Prompt audit queue"
+                loading={loading}
+            />
+            <HUDCard
+                id="collab" label="Collab"
+                value={collabSynergy?.snapshot ? `${collabSynergy.snapshot.momentum_pct > 0 ? '+' : ''}${collabSynergy.snapshot.momentum_pct}%` : "..."}
+                sub={collabSynergy?.snapshot?.total_7d !== undefined ? `7D Total: ${collabSynergy.snapshot.total_7d}w` : "Team Synergy"}
+                active={activeMetric === 'collab'}
+                status={collabSynergy?.snapshot?.momentum_pct >= 0 ? "good" : "warning"}
+                onClick={setActiveMetric}
+                tooltip={`Hot Bridge: ${collabSynergy?.snapshot?.hot_bridge || 'None'}`}
+                loading={loading}
+            />
+            <HUDCard
+                id="graph" label="Graph"
+                value={knowledgeRoi?.overall_conversion !== undefined ? `${knowledgeRoi.overall_conversion}%` : "..."}
+                sub={`${overview?.knowledge_stats?.total_nodes || 0} Total Nodes`}
+                active={activeMetric === 'graph'}
+                status={knowledgeRoi?.overall_conversion > 70 ? 'good' : knowledgeRoi?.overall_conversion > 30 ? 'warning' : 'bad'}
+                onClick={setActiveMetric}
+                tooltip="Intelligence ROI: Pages Saved vs URLs Scanned"
+                loading={loading}
+            />
+            <HUDCard
+                id="velocity" label="Reliability"
+                value={slaReliability?.current_sla !== undefined ? `${slaReliability.current_sla}%` : "..."}
+                sub="SLA Attainment"
+                active={activeMetric === 'velocity'}
+                status={slaReliability?.current_sla >= 95 ? "good" : "warning"}
+                onClick={setActiveMetric}
+                tooltip="6-Month Strategic Discipline Trend"
+                loading={loading}
+            />
+            <HUDCard
+                id="prompts" label="Prompts"
+                value="System"
+                sub="Management"
+                active={activeMetric === 'prompts'}
+                status="neutral"
+                onClick={setActiveMetric}
+                tooltip="System Prompts Management"
+                loading={loading}
+            />
+        </div>
+    );
+};

--- a/enduser-ui-fe/src/features/manager/components/nexus/NexusHeader.tsx
+++ b/enduser-ui-fe/src/features/manager/components/nexus/NexusHeader.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { FileTextIcon, ClockIcon } from '../../../../components/Icons';
+
+export interface NexusHeaderProps {
+    onOpenSpec: () => void;
+}
+
+export const NexusHeader: React.FC<NexusHeaderProps> = ({ onOpenSpec }) => {
+    return (
+        <header className="flex justify-between items-end mb-8">
+            <div>
+                <h1 className="text-3xl font-bold text-gray-900 dark:text-white tracking-tight flex items-center gap-3">Manager Nexus</h1>
+                <p className="text-sm text-gray-500 mt-1 font-medium">Command & Control v7.1</p>
+            </div>
+            <div className="flex items-center gap-4">
+                <button
+                    onClick={onOpenSpec}
+                    className="flex items-center gap-2 px-4 py-2 bg-amber-50 text-amber-600 rounded-xl text-xs font-black uppercase tracking-widest hover:bg-amber-100 transition-all active:scale-95 border border-amber-100"
+                >
+                    <FileTextIcon className="w-4 h-4" />
+                    View Specs
+                </button>
+                <div className="flex gap-2 text-xs font-bold text-gray-400 bg-white px-3 py-1.5 rounded-lg border border-gray-100 shadow-sm">
+                    <ClockIcon className="w-4 h-4" />
+                    <span>Dynamic Refresh</span>
+                </div>
+            </div>
+        </header>
+    );
+};

--- a/enduser-ui-fe/src/features/manager/components/nexus/NexusSpecPanel.tsx
+++ b/enduser-ui-fe/src/features/manager/components/nexus/NexusSpecPanel.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import { motion, AnimatePresence } from 'framer-motion';
+import { FileTextIcon, XIcon } from '../../../../components/Icons';
+
+export interface NexusSpecPanelProps {
+    isOpen: boolean;
+    onClose: () => void;
+    specContent: string;
+}
+
+export const NexusSpecPanel: React.FC<NexusSpecPanelProps> = ({ isOpen, onClose, specContent }) => {
+    return (
+        <AnimatePresence>
+            {isOpen && (
+                <>
+                    {/* Backdrop */}
+                    <motion.div
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        onClick={onClose}
+                        className="fixed inset-0 bg-slate-900/40 backdrop-blur-sm z-[70]"
+                    />
+                    {/* Panel */}
+                    <motion.aside
+                        initial={{ x: '100%' }}
+                        animate={{ x: 0 }}
+                        exit={{ x: '100%' }}
+                        transition={{ type: 'spring', damping: 25, stiffness: 200 }}
+                        className="fixed inset-y-0 right-0 w-full max-w-xl bg-white dark:bg-slate-900 shadow-2xl z-[80] overflow-hidden flex flex-col"
+                    >
+                        <div className="p-6 border-b border-gray-100 dark:border-slate-800 flex justify-between items-center bg-amber-50/30 dark:bg-amber-900/10">
+                            <div className="flex items-center gap-3">
+                                <div className="p-2 bg-amber-500 rounded-lg text-white">
+                                    <FileTextIcon className="w-5 h-5" />
+                                </div>
+                                <h2 className="text-lg font-black text-gray-900 dark:text-white uppercase tracking-tight">Nexus Metrics Spec</h2>
+                            </div>
+                            <button onClick={onClose} className="p-2 hover:bg-gray-200/50 dark:hover:bg-slate-800 rounded-full transition-colors text-gray-400" aria-label="Close Nexus Metrics Spec">
+                                <XIcon className="w-6 h-6" />
+                            </button>
+                        </div>
+                        <div className="flex-1 overflow-y-auto p-8 prose prose-slate dark:prose-invert max-w-none prose-headings:font-black prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg">
+                            <ReactMarkdown>{specContent}</ReactMarkdown>
+                        </div>
+                        <div className="p-6 border-t border-gray-100 dark:border-slate-800 bg-gray-50/50 dark:bg-slate-950/50 flex justify-end">
+                            <button
+                                onClick={onClose}
+                                className="px-6 py-2 bg-gray-900 dark:bg-white text-white dark:text-gray-900 rounded-xl font-bold text-sm hover:scale-105 transition-transform"
+                            >
+                                Close Spec
+                            </button>
+                        </div>
+                    </motion.aside>
+                </>
+            )}
+        </AnimatePresence>
+    );
+};

--- a/enduser-ui-fe/src/pages/ManagerNexus.tsx
+++ b/enduser-ui-fe/src/pages/ManagerNexus.tsx
@@ -1,13 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import ReactMarkdown from 'react-markdown';
-import { motion, AnimatePresence } from 'framer-motion';
 import { Employee } from '../types';
 import { 
-    CheckCircleIcon, AlertTriangleIcon, ActivityIcon, 
+    AlertTriangleIcon, ActivityIcon,
     ShieldCheckIcon, DatabaseIcon, UsersIcon, 
     GitCommitIcon, FileTextIcon,
-    DollarSignIcon, ClockIcon, ZapIcon,
-    XIcon,
+    DollarSignIcon, ClockIcon,
     RefreshCwIcon
 } from '../components/Icons';
 import { ManageMemberModal } from '../features/team/components/ManageMemberModal';
@@ -17,7 +14,6 @@ import { IntegrityAnalysis } from '../features/manager/components/IntegrityAnaly
 
 import { useManagerNexusStats, MetricCategory } from '../features/manager/hooks/useManagerNexusStats';
 import { Skeleton } from '../components/Skeleton';
-import { HUDCard } from '../features/manager/components/HUDCard';
 import { DetailSection } from '../features/manager/components/DetailSection';
 import { ResourceAudit } from '../features/manager/components/ResourceAudit';
 import { OpLoadPanel } from '../features/manager/components/OpLoadPanel';
@@ -26,6 +22,14 @@ import { SentinelRadar } from '../features/manager/components/SentinelRadar';
 import { ActiveForce } from '../features/manager/components/ActiveForce';
 import { KnowledgeROI } from '../features/manager/components/KnowledgeROI';
 import { SlaReliability } from '../features/manager/components/SlaReliability';
+
+// Nexus Components
+import { NexusHeader } from '../features/manager/components/nexus/NexusHeader';
+import { NexusFooter } from '../features/manager/components/nexus/NexusFooter';
+import { NexusHUD } from '../features/manager/components/nexus/NexusHUD';
+import { EthicsAuditPanel } from '../features/manager/components/nexus/EthicsAuditPanel';
+import { NexusSpecPanel } from '../features/manager/components/nexus/NexusSpecPanel';
+import { NexusEmptyState } from '../features/manager/components/nexus/NexusEmptyState';
 
 // --- Components ---
 
@@ -55,38 +59,6 @@ export const ManagerNexus: React.FC = () => {
             .then(setSpecContent)
             .catch(err => console.error("Failed to load specs:", err));
     }, []);
-
-    const handleViewDiff = (item: any) => {
-        try {
-            if (!item) return;
-            let contentData = item.content;
-            if (typeof item.content === 'string') {
-                try {
-                    contentData = JSON.parse(item.content);
-                } catch (e) {
-                    contentData = { raw: item.content };
-                }
-            }
-            const summary = item.change_summary || "Strategic Prompt Update";
-            const field = item.field_name || "Prompt Config";
-            const author = item.created_by || "System";
-            const displayStr = typeof contentData === 'string' ? contentData : JSON.stringify(contentData, null, 2);
-
-            alert(
-                `[ AUDIT VIEW: PROMPT CHANGE ]\n` +
-                `----------------------------------\n` +
-                `Target: ${item.document_id}\n` +
-                `Author: ${author}\n` +
-                `Field:  ${field}\n` +
-                `Summary: ${summary}\n\n` +
-                `NEW CONTENT PREVIEW:\n` +
-                `${displayStr.slice(0, 400)}${displayStr.length > 400 ? '...' : ''}`
-            );
-        } catch (err) {
-            console.error("ViewDiff Failed:", err);
-            alert("Unable to preview this change. The data format might be incompatible.");
-        }
-    };
 
     // --- Renders ---
 
@@ -185,76 +157,12 @@ export const ManagerNexus: React.FC = () => {
             case 'ethics':
                 return (
                     <DetailSection title="Ethics & Prompt Audit" subtitle="Compliance Resolution Center" icon={<ShieldCheckIcon className="w-5 h-5 text-indigo-600"/>}>
-                        <div className="space-y-6">
-                            <div className="bg-indigo-50/30 border border-indigo-100 rounded-3xl p-6">
-                                <h4 className="text-xs font-black text-indigo-900 uppercase tracking-widest mb-4 flex items-center gap-2">
-                                    <ZapIcon className="w-3 h-3" /> Actionable Safety Queue ({ethicsAudit?.total_pending || 0})
-                                </h4>
-                                
-                                <div className="space-y-4">
-                                    {/* 1. Ethics Violations (Sentinel) */}
-                                    {ethicsAudit?.violations.map((v: any) => (
-                                        <div key={v.id} className="bg-white border border-red-100 p-4 rounded-2xl flex items-center justify-between shadow-sm hover:shadow-md transition-all">
-                                            <div className="flex items-center gap-4">
-                                                <div className="bg-red-50 p-3 rounded-xl text-red-600">
-                                                    <ShieldCheckIcon className="w-5 h-5" />
-                                                </div>
-                                                <div>
-                                                    <span className="text-[10px] font-black px-2 py-0.5 bg-red-100 text-red-700 rounded uppercase">Safety Intercept</span>
-                                                    <h5 className="font-bold text-gray-800 text-sm mt-1">{v.event_type}: {v.description}</h5>
-                                                    <p className="text-[10px] text-gray-400 font-mono mt-0.5">Attempted Input: {v.raw_input?.slice(0, 50)}...</p>
-                                                </div>
-                                            </div>
-                                            <button 
-                                                onClick={() => handleDispatch(v.id)}
-                                                className="px-4 py-2 bg-red-600 text-white rounded-xl text-[10px] font-black hover:bg-red-700 transition-all"
-                                            >
-                                                DISPATCH INVESTIGATION
-                                            </button>
-                                        </div>
-                                    ))}
-
-                                    {/* 2. Prompt Changes (Librarian) */}
-                                    {ethicsAudit?.pending_versions.map((p: any) => (
-                                        <div key={p.id} className="bg-white border border-amber-100 p-4 rounded-2xl flex items-center justify-between shadow-sm hover:shadow-md transition-all">
-                                            <div className="flex items-center gap-4">
-                                                <div className="bg-amber-50 p-3 rounded-xl text-amber-600">
-                                                    <FileTextIcon className="w-5 h-5" />
-                                                </div>
-                                                <div>
-                                                    <span className="text-[10px] font-black px-2 py-0.5 bg-amber-100 text-amber-700 rounded uppercase">Prompt Change</span>
-                                                    <h5 className="font-bold text-gray-800 text-sm mt-1">{p.document_id} (v{p.version_number})</h5>
-                                                    <p className="text-[10px] text-gray-400 font-mono mt-0.5">Changed by {p.created_by} | {p.change_summary}</p>
-                                                </div>
-                                            </div>
-                                            <div className="flex gap-2">
-                                                <button 
-                                                    onClick={() => handleViewDiff(p)}
-                                                    className="px-4 py-2 bg-slate-100 text-slate-600 rounded-xl text-[10px] font-black hover:bg-slate-200"
-                                                >
-                                                    VIEW DIFF
-                                                </button>
-                                                <button 
-                                                    onClick={() => handleApprovePrompt(p.id)}
-                                                    disabled={processingId === p.id}
-                                                    className="px-4 py-2 bg-indigo-600 text-white rounded-xl text-[10px] font-black hover:bg-indigo-700"
-                                                >
-                                                    {processingId === p.id ? '...' : 'APPROVE'}
-                                                </button>
-                                            </div>
-                                        </div>
-                                    ))}
-
-                                    {ethicsAudit?.total_pending === 0 && (
-                                        <div className="py-12 flex flex-col items-center justify-center text-center text-green-600 opacity-60">
-                                            <CheckCircleIcon className="w-12 h-12 mb-2" />
-                                            <p className="text-sm font-black uppercase tracking-widest">Compliance Nominal</p>
-                                            <p className="text-[10px]">No unauthorized prompt changes or safety leaks detected.</p>
-                                        </div>
-                                    )}
-                                </div>
-                            </div>
-                        </div>
+                        <EthicsAuditPanel
+                            ethicsAudit={ethicsAudit}
+                            handleDispatch={handleDispatch}
+                            handleApprovePrompt={handleApprovePrompt}
+                            processingId={processingId}
+                        />
                     </DetailSection>
                 );
 
@@ -272,142 +180,29 @@ export const ManagerNexus: React.FC = () => {
                 );
 
             default:
-                return (
-                    <div className="p-12 text-center text-gray-400 bg-white rounded-3xl border border-dashed border-gray-200">
-                        <ActivityIcon className="w-12 h-12 mx-auto mb-4 opacity-20" />
-                        <p>Select a metric above to view details.</p>
-                    </div>
-                );
+                return <NexusEmptyState />;
         }
     };
 
 
     return (
         <div className="p-4 md:p-8 max-w-7xl mx-auto space-y-8 min-h-screen bg-gray-50/50 font-sans nexus-font-scope" style={{fontFamily: "'Inter', sans-serif"}}>
-             <header className="flex justify-between items-end mb-8">
-                <div>
-                    <h1 className="text-3xl font-bold text-gray-900 dark:text-white tracking-tight flex items-center gap-3">Manager Nexus</h1>
-                    <p className="text-sm text-gray-500 mt-1 font-medium">Command & Control v7.1</p>
-                </div>
-                <div className="flex items-center gap-4">
-                    <button 
-                        onClick={() => setIsSpecOpen(true)}
-                        className="flex items-center gap-2 px-4 py-2 bg-amber-50 text-amber-600 rounded-xl text-xs font-black uppercase tracking-widest hover:bg-amber-100 transition-all active:scale-95 border border-amber-100"
-                    >
-                        <FileTextIcon className="w-4 h-4" />
-                        View Specs
-                    </button>
-                    <div className="flex gap-2 text-xs font-bold text-gray-400 bg-white px-3 py-1.5 rounded-lg border border-gray-100 shadow-sm">
-                        <ClockIcon className="w-4 h-4" />
-                        <span>Dynamic Refresh</span>
-                    </div>
-                </div>
-            </header>
+             <NexusHeader onOpenSpec={() => setIsSpecOpen(true)} />
 
             {/* HUD Grid */}
-            <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-                <HUDCard 
-                    id="integrity" label="Integrity" 
-                    value={overview?.integrity_score !== undefined ? `${overview.integrity_score}%` : "..."}
-                    sub="System Health" 
-                    active={activeMetric === 'integrity'} 
-                    status={overview?.status === 'healthy' ? 'good' : 'bad'} 
-                    onClick={setActiveMetric} 
-                    tooltip="RAG Vector DB Health"
-                    loading={loading}
-                />
-                <HUDCard 
-                    id="resources" label="Resources" 
-                    value={`$${(overview?.cost_24h || 0).toFixed(2)}`} 
-                    sub="Monthly Cap" 
-                    active={activeMetric === 'resources'} 
-                    status="neutral" 
-                    onClick={setActiveMetric} 
-                    tooltip="Token Usage & Cost vs Budget"
-                    loading={loading}
-                />
-                <HUDCard 
-                    id="op_load" label="Op Load" 
-                    value={`${approvals.blogs.length + approvals.leads.length} Items`} 
-                    sub="Decision Queue" 
-                    active={activeMetric === 'op_load'} 
-                    status={approvals.blogs.length > 0 ? "warning" : "good"} 
-                    onClick={setActiveMetric}
-                    tooltip="Pending Approvals & Reviews" 
-                    loading={loading}
-                />
-                <HUDCard 
-                    id="sent_risks" label="Sent Risks" 
-                    value={`${alerts.length} Alerts`} 
-                    sub="Exception Radar" 
-                    active={activeMetric === 'sent_risks'} 
-                    status={alerts.length > 0 ? "bad" : "good"} 
-                    onClick={setActiveMetric} 
-                    tooltip="Sentinel Generated Alerts"
-                    loading={loading}
-                />
-                <HUDCard 
-                    id="active_force" label="Act Force" 
-                    value={`${team.filter(m=>m.status==='active').length} Online`} 
-                    sub="Roster Status" 
-                    active={activeMetric === 'active_force'} 
-                    status="good" 
-                    onClick={setActiveMetric} 
-                    tooltip="Team & Agent Availability"
-                    loading={loading}
-                />
-                {/* Secondary Metrics Row */}
-                <HUDCard 
-                    id="ethics" label="Ethics" 
-                    value={ethicsAudit?.total_pending > 0 ? `${ethicsAudit.total_pending} Actions` : "Secure"} 
-                    sub={ethicsAudit?.total_pending > 0 ? `${ethicsAudit.violations.length} Risks | ${ethicsAudit.pending_versions.length} Changes` : "System Nominal"} 
-                    active={activeMetric === 'ethics'} 
-                    status={ethicsAudit?.total_pending > 0 ? 'bad' : 'good'} 
-                    onClick={setActiveMetric} 
-                    tooltip="Safety violations & Prompt audit queue" 
-                    loading={loading}
-                />
-                <HUDCard 
-                    id="collab" label="Collab" 
-                    value={collabSynergy?.snapshot ? `${collabSynergy.snapshot.momentum_pct > 0 ? '+' : ''}${collabSynergy.snapshot.momentum_pct}%` : "..."} 
-                    sub={collabSynergy?.snapshot?.total_7d !== undefined ? `7D Total: ${collabSynergy.snapshot.total_7d}w` : "Team Synergy"}
-                    active={activeMetric === 'collab'} 
-                    status={collabSynergy?.snapshot?.momentum_pct >= 0 ? "good" : "warning"} 
-                    onClick={setActiveMetric} 
-                    tooltip={`Hot Bridge: ${collabSynergy?.snapshot?.hot_bridge || 'None'}`} 
-                    loading={loading}
-                />
-                <HUDCard 
-                    id="graph" label="Graph" 
-                    value={knowledgeRoi?.overall_conversion !== undefined ? `${knowledgeRoi.overall_conversion}%` : "..."} 
-                    sub={`${overview?.knowledge_stats?.total_nodes || 0} Total Nodes`} 
-                    active={activeMetric === 'graph'} 
-                    status={knowledgeRoi?.overall_conversion > 70 ? 'good' : knowledgeRoi?.overall_conversion > 30 ? 'warning' : 'bad'} 
-                    onClick={setActiveMetric} 
-                    tooltip="Intelligence ROI: Pages Saved vs URLs Scanned" 
-                    loading={loading}
-                />
-                <HUDCard 
-                    id="velocity" label="Reliability" 
-                    value={slaReliability?.current_sla !== undefined ? `${slaReliability.current_sla}%` : "..."} 
-                    sub="SLA Attainment" 
-                    active={activeMetric === 'velocity'} 
-                    status={slaReliability?.current_sla >= 95 ? "good" : "warning"} 
-                    onClick={setActiveMetric} 
-                    tooltip="6-Month Strategic Discipline Trend" 
-                    loading={loading}
-                />
-                <HUDCard 
-                    id="prompts" label="Prompts" 
-                    value="System" 
-                    sub="Management" 
-                    active={activeMetric === 'prompts'} 
-                    status="neutral" 
-                    onClick={setActiveMetric} 
-                    tooltip="System Prompts Management" 
-                    loading={loading}
-                />
-            </div>
+            <NexusHUD
+                activeMetric={activeMetric}
+                setActiveMetric={setActiveMetric}
+                loading={loading}
+                overview={overview}
+                approvals={approvals}
+                alerts={alerts}
+                team={team}
+                ethicsAudit={ethicsAudit}
+                collabSynergy={collabSynergy}
+                knowledgeRoi={knowledgeRoi}
+                slaReliability={slaReliability}
+            />
 
             {/* Dynamic Detail Area */}
             <div className="min-h-[400px]">
@@ -426,29 +221,7 @@ export const ManagerNexus: React.FC = () => {
                 )}
             </div>
 
-            {/* Footer Field Guide */}
-            <footer className="mt-12 pt-8 border-t border-gray-200 text-xs text-gray-400 grid grid-cols-1 md:grid-cols-3 gap-8">
-                <div>
-                    <h5 className="font-bold text-gray-500 uppercase tracking-widest mb-2">Metrics Definition</h5>
-                    <ul className="space-y-1">
-                        <li>• <strong className="text-gray-600">Reliability:</strong> 6-month strategic SLA attainment (Bi-weekly).</li>
-                        <li>• <strong className="text-gray-600">ROI:</strong> 60-day intelligence yield (Pages Saved / URLs Scanned).</li>
-                    </ul>
-                </div>
-                <div>
-                     <h5 className="font-bold text-gray-500 uppercase tracking-widest mb-2">Color Codes</h5>
-                     <ul className="space-y-1">
-                        <li className="flex items-center gap-2"><div className="w-2 h-2 bg-green-500 rounded-full"></div> Optimal Range</li>
-                        <li className="flex items-center gap-2"><div className="w-2 h-2 bg-amber-500 rounded-full"></div> Warning / Action Needed</li>
-                        <li className="flex items-center gap-2"><div className="w-2 h-2 bg-red-500 rounded-full"></div> Critical Exception</li>
-                     </ul>
-                </div>
-                <div>
-                    <h5 className="font-bold text-gray-500 uppercase tracking-widest mb-2">System Info</h5>
-                    <p>ManagerNexus v7.1 | Build 2026.02.12</p>
-                    <p className="mt-1">© Archon Intelligence Systems</p>
-                </div>
-            </footer>
+            <NexusFooter />
 
             {/* Member Management Modal */}
             {selectedMember && (
@@ -463,51 +236,11 @@ export const ManagerNexus: React.FC = () => {
             )}
 
             {/* Nexus Spec Slide-over Panel */}
-            <AnimatePresence>
-                {isSpecOpen && (
-                    <>
-                        {/* Backdrop */}
-                        <motion.div 
-                            initial={{ opacity: 0 }}
-                            animate={{ opacity: 1 }}
-                            exit={{ opacity: 0 }}
-                            onClick={() => setIsSpecOpen(false)}
-                            className="fixed inset-0 bg-slate-900/40 backdrop-blur-sm z-[70]"
-                        />
-                        {/* Panel */}
-                        <motion.aside 
-                            initial={{ x: '100%' }}
-                            animate={{ x: 0 }}
-                            exit={{ x: '100%' }}
-                            transition={{ type: 'spring', damping: 25, stiffness: 200 }}
-                            className="fixed inset-y-0 right-0 w-full max-w-xl bg-white dark:bg-slate-900 shadow-2xl z-[80] overflow-hidden flex flex-col"
-                        >
-                            <div className="p-6 border-b border-gray-100 dark:border-slate-800 flex justify-between items-center bg-amber-50/30 dark:bg-amber-900/10">
-                                <div className="flex items-center gap-3">
-                                    <div className="p-2 bg-amber-500 rounded-lg text-white">
-                                        <FileTextIcon className="w-5 h-5" />
-                                    </div>
-                                    <h2 className="text-lg font-black text-gray-900 dark:text-white uppercase tracking-tight">Nexus Metrics Spec</h2>
-                                </div>
-                                <button onClick={() => setIsSpecOpen(false)} className="p-2 hover:bg-gray-200/50 dark:hover:bg-slate-800 rounded-full transition-colors text-gray-400" aria-label="Close Nexus Metrics Spec">
-                                    <XIcon className="w-6 h-6" />
-                                </button>
-                            </div>
-                            <div className="flex-1 overflow-y-auto p-8 prose prose-slate dark:prose-invert max-w-none prose-headings:font-black prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg">
-                                <ReactMarkdown>{specContent}</ReactMarkdown>
-                            </div>
-                            <div className="p-6 border-t border-gray-100 dark:border-slate-800 bg-gray-50/50 dark:bg-slate-950/50 flex justify-end">
-                                <button 
-                                    onClick={() => setIsSpecOpen(false)}
-                                    className="px-6 py-2 bg-gray-900 dark:bg-white text-white dark:text-gray-900 rounded-xl font-bold text-sm hover:scale-105 transition-transform"
-                                >
-                                    Close Spec
-                                </button>
-                            </div>
-                        </motion.aside>
-                    </>
-                )}
-            </AnimatePresence>
+            <NexusSpecPanel
+                isOpen={isSpecOpen}
+                onClose={() => setIsSpecOpen(false)}
+                specContent={specContent}
+            />
         </div>
     );
 };


### PR DESCRIPTION
This PR addresses the refactoring of `ManagerNexus.tsx` by breaking down its bloated logic and extracting specific functional and static components into a new `nexus/` directory to improve maintainability and performance.

### Changes Made:
1. Created `enduser-ui-fe/src/features/manager/components/nexus/` directory.
2. Extracted `NexusHeader` (Title, Specs Button).
3. Extracted `NexusFooter` (Metrics definitions, Color codes, System Info).
4. Extracted `NexusSpecPanel` (Slide-over markdown viewer, isolating `framer-motion` and `react-markdown`).
5. Extracted `EthicsAuditPanel` and fully encapsulated the `handleViewDiff` method.
6. Extracted `NexusHUD` to manage the 10 HUD Cards.
7. Extracted `NexusEmptyState` for the default render case.
8. Refactored `ManagerNexus.tsx` to utilize these new components, significantly reducing its line count and visual complexity.

### Verification:
- Build and type-checking pass (`pnpm build`).
- Unit tests pass (`pnpm test:unit`).
- Verified components render correctly via Playwright screenshot capturing (with the note that full visual auth verification requires complex test mocking).
- Code reviewed and approved as meeting all specified constraints.

---
*PR created automatically by Jules for task [1779929050855132387](https://jules.google.com/task/1779929050855132387) started by @info-vin*