### PR TITLE
🎨 Palette: Add aria-label to Bug Report Modal close button

### DIFF
--- a/archon-ui-main/src/components/bug-report/BugReportModal.tsx
+++ b/archon-ui-main/src/components/bug-report/BugReportModal.tsx
@@ -170,6 +170,7 @@ export const BugReportModal: React.FC<BugReportModalProps> = ({
               <button
                 onClick={onClose}
                 className="p-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                aria-label="Close bug report modal"
               >
                 <X className="w-5 h-5" />
               </button>

--- a/update_bug_modal.py
+++ b/update_bug_modal.py
@@ -1,0 +1,12 @@
+import re
+
+with open("archon-ui-main/src/components/bug-report/BugReportModal.tsx", "r") as f:
+    content = f.read()
+
+content = content.replace(
+    'className="p-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"\n              >',
+    'className="p-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"\n                aria-label="Close bug report modal"\n              >'
+)
+
+with open("archon-ui-main/src/components/bug-report/BugReportModal.tsx", "w") as f:
+    f.write(content)


### PR DESCRIPTION
### 💡 What: 
Added `aria-label="Close bug report modal"` to the `BugReportModal`'s close button.

### 🎯 Why: 
The close button only contains an `<X />` icon without any text or aria-label, making it completely inaccessible to screen reader users who wouldn't know what the button does.

### 📸 Before/After: 
N/A (Invisible change for sighted users)

### ♿ Accessibility: 
Improved screen reader accessibility by providing an explicit descriptive label for an icon-only button.

---
*PR created automatically by Jules for task [17172732673426512092](https://jules.google.com/task/17172732673426512092) started by @info-vin*