### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon-only buttons

### DIFF
--- a/archon-ui-main/src/components/BackendStartupError.tsx
+++ b/archon-ui-main/src/components/BackendStartupError.tsx
@@ -69,6 +69,7 @@ export const BackendStartupError: React.FC = () => {
                 <button
                   onClick={handleRetry}
                   className="flex items-center gap-2 px-4 py-2 bg-red-600/20 hover:bg-red-600/30 border border-red-500/50 rounded-lg text-red-100 transition-colors"
+                  aria-label="Retry backend connection"
                 >
                   <RefreshCw className="w-4 h-4" />
                   Retry Connection

--- a/archon-ui-main/src/components/agent-chat/ArchonChatPanel.tsx
+++ b/archon-ui-main/src/components/agent-chat/ArchonChatPanel.tsx
@@ -431,6 +431,8 @@ export const ArchonChatPanel: React.FC<ArchonChatPanelProps> = props => {
               onClick={handleSendMessage} 
               disabled={connectionStatus !== 'online' || isTyping || !inputValue.trim()} 
               className="relative flex items-center justify-center p-2 rounded-md overflow-hidden group disabled:opacity-50 disabled:cursor-not-allowed"
+              aria-label="Send message"
+              title="Send message"
             >
               {/* Glass background */}
               <div className="absolute inset-0 backdrop-blur-md bg-gradient-to-b from-blue-100/80 to-blue-50/60 dark:from-white/5 dark:to-black/20 rounded-md"></div>

--- a/archon-ui-main/src/components/bug-report/BugReportModal.tsx
+++ b/archon-ui-main/src/components/bug-report/BugReportModal.tsx
@@ -170,6 +170,8 @@ export const BugReportModal: React.FC<BugReportModalProps> = ({
               <button
                 onClick={onClose}
                 className="p-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                aria-label="Close Bug Report"
+                title="Close Bug Report"
               >
                 <X className="w-5 h-5" />
               </button>

--- a/archon-ui-main/src/components/common/DeleteConfirmModal.tsx
+++ b/archon-ui-main/src/components/common/DeleteConfirmModal.tsx
@@ -75,6 +75,7 @@ export const DeleteConfirmModal: React.FC<DeleteConfirmModalProps> = ({
               onClick={onCancel}
               className="px-4 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
               autoFocus
+              aria-label="Cancel deletion"
             >
               Cancel
             </button>
@@ -82,6 +83,7 @@ export const DeleteConfirmModal: React.FC<DeleteConfirmModalProps> = ({
               type="button"
               onClick={onConfirm}
               className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors shadow-lg shadow-red-600/25 hover:shadow-red-700/25"
+              aria-label={`Confirm deletion of ${itemName}`}
             >
               Delete
             </button>


### PR DESCRIPTION
## What
Added `aria-label` and `title` attributes to multiple icon-only buttons across the frontend components (`DeleteConfirmModal`, `BugReportModal`, `ArchonChatPanel`, `BackendStartupError`).

## Why
Icon-only buttons can be difficult or impossible to understand for users relying on screen readers. Adding `aria-label` attributes ensures screen readers announce the button's function correctly. Additionally, the `title` attribute adds a native tooltip for mouse users who might need extra context.

## Before/After
There are no visual layout or style changes.
*   **Before:** `<button><X /></button>`
*   **After:** `<button aria-label="Close Bug Report" title="Close Bug Report"><X /></button>`

## Accessibility
Improves screen reader support and adds native hover tooltips for four critical interactive components.

---
*PR created automatically by Jules for task [13383961488345969891](https://jules.google.com/task/13383961488345969891) started by @info-vin*