### PR TITLE
🎨 Palette: Improve accessibility for grouped card actions

### DIFF
--- a/archon-ui-main/src/features/projects/components/ProjectCardActions.tsx
+++ b/archon-ui-main/src/features/projects/components/ProjectCardActions.tsx
@@ -46,7 +46,7 @@ export const ProjectCardActions: React.FC<ProjectCardActionsProps> = ({
     }
   };
   return (
-    <div className="flex items-center gap-1.5">
+    <div className="flex items-center gap-1.5" role="group" aria-label="Project Actions">
       {/* Delete Button */}
       <SimpleTooltip content={isDeleting ? "Deleting..." : "Delete project"}>
         <button

--- a/archon-ui-main/src/features/projects/tasks/components/TaskCardActions.tsx
+++ b/archon-ui-main/src/features/projects/tasks/components/TaskCardActions.tsx
@@ -45,7 +45,7 @@ export const TaskCardActions: React.FC<TaskCardActionsProps> = ({
   };
 
   return (
-    <div className="flex items-center gap-1.5">
+    <div className="flex items-center gap-1.5" role="group" aria-label="Task Actions">
       <SimpleTooltip content={isDeleting ? "Deleting..." : "Delete task"}>
         <button
           type="button"


### PR DESCRIPTION
💡 **What:** Added `role="group"` and `aria-label` to the container `div`s that hold icon-only action buttons inside `ProjectCardActions` and `TaskCardActions`.
🎯 **Why:** Previously, these action buttons (Delete, Pin, Copy ID, Edit) were just loose buttons inside a div. When a screen reader user encounters them, they lack the contextual grouping to understand what they are acting upon. By wrapping them in a group with an `aria-label` (e.g., "Project Actions", "Task Actions"), screen readers will announce the group context before the individual button labels, drastically improving navigability.
📸 **Before/After:** The changes are purely structural and do not affect the visual layout.
♿ **Accessibility:**
- Added `role="group"` to the flex container for action buttons.
- Added `aria-label="Project Actions"` and `aria-label="Task Actions"` to provide clear context.
- Ensured no duplicate native `title` attributes were added since these buttons are already wrapped in `<SimpleTooltip>` components, avoiding visual "double tooltip" clutter while maintaining a11y standards.

---
*PR created automatically by Jules for task [6736499774202422105](https://jules.google.com/task/6736499774202422105) started by @info-vin*