### PR TITLE
🎨 Palette: Improve chat panel accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-03-03 - Missing ARIA Labels on Close Modals
 **Learning:** Icon-only close buttons (`XIcon`) across various feature components (`ContentWorkbench`, `ManagerNexus`, `LeadsCardStack`, `BrandWorkbenchView`) frequently lack `aria-label` attributes, causing them to be announced simply as "button" by screen readers.
 **Action:** When implementing modal or panel close actions using `XIcon` or similar icon-only buttons, always explicitly add an `aria-label` attribute (e.g., `aria-label="Close modal"` or a more descriptive label like `aria-label="Close AI Command Center"`).
+
+## $(date +%Y-%m-%d) - Dynamic ARIA Labels on State-Changing Buttons
+**Learning:** When adding `aria-label` attributes to buttons with dynamic inner text (like changing from "Reconnect" to "Connecting..."), a static `aria-label` causes screen readers to ignore the dynamic text, losing important state context.
+**Action:** Always make the `aria-label` dynamic (e.g., `aria-label={isLoading ? "Connecting to chat" : "Reconnect to chat"}`) to match the button's visual state.

--- a/archon-ui-main/src/components/agent-chat/ArchonChatPanel.tsx
+++ b/archon-ui-main/src/components/agent-chat/ArchonChatPanel.tsx
@@ -245,7 +245,14 @@ export const ArchonChatPanel: React.FC<ArchonChatPanelProps> = props => {
       width: `${width}px`
     }} data-id={props['data-id']}>
       {/* Drag handle for resizing */}
-      <div ref={dragHandleRef} className={`absolute left-0 top-0 w-1.5 h-full cursor-ew-resize z-20 ${isDragging ? 'bg-blue-500/50' : 'bg-transparent hover:bg-blue-500/30'} transition-colors duration-200`} onMouseDown={handleDragStart} />
+      <div
+        ref={dragHandleRef}
+        className={`absolute left-0 top-0 w-1.5 h-full cursor-ew-resize z-20 ${isDragging ? 'bg-blue-500/50' : 'bg-transparent hover:bg-blue-500/30'} transition-colors duration-200`}
+        onMouseDown={handleDragStart}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize chat panel"
+      />
       {/* Main panel with glassmorphism */}
       <div className="h-full flex flex-col relative backdrop-blur-md bg-gradient-to-b from-white/80 to-white/60 dark:from-white/10 dark:to-black/30 border-l border-blue-200 dark:border-blue-500/30">
         {/* Edgelit glow effect */}
@@ -279,6 +286,7 @@ export const ArchonChatPanel: React.FC<ArchonChatPanelProps> = props => {
                   onClick={handleReconnect}
                   disabled={isReconnecting}
                   className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 bg-blue-100/80 hover:bg-blue-200/80 dark:bg-blue-900/30 dark:hover:bg-blue-800/40 px-2 py-1 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  aria-label={isReconnecting ? "Connecting to chat" : "Reconnect to chat"}
                 >
                   <RefreshCw className={`w-3 h-3 ${isReconnecting ? 'animate-spin' : ''}`} />
                   {isReconnecting ? 'Connecting...' : 'Reconnect'}


### PR DESCRIPTION
**What:**
Added `aria-label` to the "Reconnect" button, and added `role="separator"`, `aria-orientation="vertical"`, and `aria-label` to the chat panel drag handle.

**Why:**
To improve the experience for screen reader users by providing semantic meaning to the interactive drag handle and clear, dynamic state feedback for the reconnect action button.

**Before/After:**
Verification snapshot (verification.png) is included locally; no visual regressions introduced.

**Accessibility:**
- Added `aria-label` which updates dynamically during the "Connecting..." state.
- Applied `role="separator"` and `aria-label` to structural elements acting as resize handlers.

---
*PR created automatically by Jules for task [6295226190579623094](https://jules.google.com/task/6295226190579623094) started by @info-vin*