### PR TITLE
🎨 Palette: [a11y] Add ARIA labels to PowerButton and Settings toggle

### DIFF
--- a/archon-ui-main/src/components/ui/PowerButton.tsx
+++ b/archon-ui-main/src/components/ui/PowerButton.tsx
@@ -6,6 +6,7 @@ interface PowerButtonProps {
   onClick: () => void;
   color?: 'purple' | 'green' | 'pink' | 'blue' | 'cyan' | 'orange';
   size?: number;
+  ariaLabel?: string;
 }
 
 // Helper function to get color hex values for animations
@@ -25,7 +26,8 @@ export const PowerButton: React.FC<PowerButtonProps> = ({
   isOn,
   onClick,
   color = 'blue',
-  size = 40
+  size = 40,
+  ariaLabel
 }) => {
   const colorMap = {
     purple: {
@@ -77,6 +79,7 @@ export const PowerButton: React.FC<PowerButtonProps> = ({
   return (
     <motion.button
       onClick={onClick}
+      aria-label={ariaLabel || (isOn ? 'Turn off' : 'Turn on')}
       className={`
         relative rounded-full border-2 transition-all duration-300
         ${styles.border}

--- a/archon-ui-main/src/pages/SettingsPage.tsx
+++ b/archon-ui-main/src/pages/SettingsPage.tsx
@@ -261,6 +261,7 @@ export const SettingsPage = (): JSX.Element => {
           onClick={() => setShowButtonPlayground(!showButtonPlayground)}
           className="relative w-8 h-8 rounded-full border border-blue-400/30 bg-blue-500/5 hover:bg-blue-500/10 transition-all duration-200 flex items-center justify-center group"
           title="Toggle Button Playground"
+          aria-label="Toggle Button Playground"
         >
           <div className="absolute inset-0 rounded-full bg-blue-500/20 blur-sm opacity-0 group-hover:opacity-100 transition-opacity" />
           <motion.div


### PR DESCRIPTION
💡 What: Added an optional `ariaLabel` prop to the generic `<PowerButton>` component, with dynamic default labels depending on the `isOn` state. Also added an `aria-label` to the icon-only toggle button in the `SettingsPage`.
🎯 Why: Icon-only buttons without `aria-label` attributes are announced simply as "button" by screen readers, providing zero context to visually impaired users. This change ensures these interactive elements are properly described.
📸 Before/After: Visuals remain entirely unchanged; this is an underlying markup improvement for assistive technology.
♿ Accessibility: Improved screen reader compatibility by explicitly defining the action of these icon-only buttons via `aria-label`.

---
*PR created automatically by Jules for task [628610187679446307](https://jules.google.com/task/628610187679446307) started by @info-vin*