### PR TITLE
⚡ Bolt: Resolve N+1 query performance bottleneck in SourceLinkingService

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 ## 2025-05-18 - Tracking O(N) generator expressions in Python queues for rate limiters
 **Learning:** In highly concurrent paths like `RateLimiter`, using an O(N) generator expression (e.g., `sum(tokens for _, tokens in deque)`) to calculate current token usage causes a significant performance bottleneck because it repeatedly loops over potentially thousands of items.
 **Action:** Replace `sum(...)` generator expressions over queues with an O(1) caching counter (e.g., `self.current_tokens`) that is incremented when adding items and decremented when removing items.
+
+## 2024-05-24 - [Resolve N+1 Query in SourceLinkingService]
+**Learning:** The `list_projects` route suffered from an N+1 query bottleneck because it looped over every project and made a separate database call to fetch its linked sources via `SourceLinkingService`.
+**Action:** Implemented a batched `in_` Supabase query for linked sources to replace `asyncio.gather` on individual queries. When hydrating lists of entities with associated table data, always batch the query by ID array rather than running queries in a loop.

--- a/python/src/server/services/projects/source_linking_service.py
+++ b/python/src/server/services/projects/source_linking_service.py
@@ -105,9 +105,51 @@ class SourceLinkingService(BaseRepository):
 
     async def format_projects_with_sources(self, projects: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """
-        Enriches a list of projects with their linked sources.
+        Enriches a list of projects with their linked sources using a single batch query.
+        Solves N+1 query performance bottleneck.
         """
-        import asyncio
+        if not projects:
+            return projects
 
-        tasks = [self.format_project_with_sources(p) for p in projects]
-        return await asyncio.gather(*tasks)
+        project_ids = [p["id"] for p in projects if "id" in p]
+        if not project_ids:
+            return projects
+
+        def _query():
+            return (
+                self.supabase_client.table("archon_project_sources")
+                .select("project_id, source_id, notes")
+                .in_("project_id", project_ids)
+                .execute()
+            )
+
+        success, result = self.execute_query(_query, "Failed to batch fetch project sources")
+
+        # Initialize empty source lists for all projects
+        for p in projects:
+            p["technical_sources"] = []
+            p["business_sources"] = []
+
+        if success:
+            sources = result.get("data", [])
+
+            # Group by project_id
+            grouped_sources = {}
+            for s in sources:
+                pid = s.get("project_id")
+                if pid not in grouped_sources:
+                    grouped_sources[pid] = {"technical": [], "business": []}
+
+                if s.get("notes") == "technical":
+                    grouped_sources[pid]["technical"].append(s["source_id"])
+                elif s.get("notes") == "business":
+                    grouped_sources[pid]["business"].append(s["source_id"])
+
+            # Map back to projects
+            for p in projects:
+                pid = p.get("id")
+                if pid in grouped_sources:
+                    p["technical_sources"] = grouped_sources[pid]["technical"]
+                    p["business_sources"] = grouped_sources[pid]["business"]
+
+        return projects


### PR DESCRIPTION
**What:**
Refactored `format_projects_with_sources` in `python/src/server/services/projects/source_linking_service.py` to use a single batched `.in_()` query instead of looping through all projects with `asyncio.gather`.

**Why:**
The previous implementation fetched linked project sources individually. When listing many projects on the `/api/projects` endpoint, this caused an N+1 query problem, severely impacting the endpoint's response time and putting unnecessary load on the database.

**Impact:**
- Significantly reduces the number of database queries required to load the project list.
- Improves response latency for the main projects dashboard by changing database lookups from $O(N)$ database round-trips to $1$.

**Measurement:**
Verified by running the full Python backend test suite (`pytest`). Response times on the `GET /api/projects` endpoint can be directly observed in network dev tools to verify the latency reduction for users with multiple projects.

---
*PR created automatically by Jules for task [10882823440868915855](https://jules.google.com/task/10882823440868915855) started by @info-vin*