### PR TITLE
🎨 Palette: Add aria-label and tooltips to icon-only buttons

### DIFF
--- a/enduser-ui-fe/src/components/ThemeToggle.tsx
+++ b/enduser-ui-fe/src/components/ThemeToggle.tsx
@@ -25,7 +25,7 @@ const ThemeToggle: React.FC<ThemeToggleProps> = ({ className }) => {
     const buttonClasses = className ?? "p-2 rounded-md hover:bg-secondary transition-colors";
 
     return (
-        <button onClick={() => setIsDarkMode(!isDarkMode)} className={buttonClasses} aria-label="Toggle theme">
+        <button onClick={() => setIsDarkMode(!isDarkMode)} className={buttonClasses} aria-label="Toggle theme" title="Toggle theme">
             {isDarkMode ? <SunIcon className="w-5 h-5" /> : <MoonIcon className="w-5 h-5" />}
         </button>
     );

--- a/enduser-ui-fe/src/pages/BrandPage.tsx
+++ b/enduser-ui-fe/src/pages/BrandPage.tsx
@@ -82,7 +82,7 @@ const BrandPage: React.FC = () => {
                     </div>
                     
                     <div className="flex items-center gap-3">
-                        <button onClick={loadData} className="p-2 hover:bg-gray-100 dark:hover:bg-slate-800 rounded-full transition-colors">
+                        <button onClick={loadData} className="p-2 hover:bg-gray-100 dark:hover:bg-slate-800 rounded-full transition-colors" aria-label="Refresh data" title="Refresh data">
                             <RefreshCwIcon className={`w-5 h-5 text-slate-400 ${loading ? 'animate-spin' : ''}`} />
                         </button>
                     </div>
@@ -135,7 +135,7 @@ const BrandPage: React.FC = () => {
                             <h3 className="text-2xl font-bold text-gray-800 dark:text-white">
                                 {editingPost ? 'Edit Asset' : 'New Asset'}
                             </h3>
-                            <button onClick={() => setIsPostModalOpen(false)} className="text-gray-400 hover:text-gray-600 transition-colors">✕</button>
+                            <button onClick={() => setIsPostModalOpen(false)} className="text-gray-400 hover:text-gray-600 transition-colors" aria-label="Close modal" title="Close modal">✕</button>
                         </div>
                         <CreatePostForm 
                             post={editingPost} 

--- a/enduser-ui-fe/src/pages/MarketingPage.tsx
+++ b/enduser-ui-fe/src/pages/MarketingPage.tsx
@@ -108,6 +108,7 @@ const MarketingPage: React.FC = () => {
           }}
           className="fixed bottom-6 right-6 w-14 h-14 bg-indigo-600 text-white rounded-full shadow-2xl flex items-center justify-center hover:bg-indigo-700 transition-all active:scale-95 z-40 md:hidden"
           title="New Visit Log"
+          aria-label="New Visit Log"
         >
           <MapPinIcon className="w-6 h-6" />
         </button>

--- a/enduser-ui-fe/src/pages/SalesCartPage.tsx
+++ b/enduser-ui-fe/src/pages/SalesCartPage.tsx
@@ -252,7 +252,7 @@ const PitchModal: React.FC<{ isOpen: boolean; onClose: () => void; content: stri
                         <SparklesIcon className="w-5 h-5 text-indigo-600" />
                         AI Pitch: {company}
                     </h3>
-                    <button onClick={onClose} className="p-1 hover:bg-gray-200 rounded-full text-gray-500 transition-colors">
+                    <button onClick={onClose} className="p-1 hover:bg-gray-200 rounded-full text-gray-500 transition-colors" aria-label="Close modal" title="Close modal">
                         <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
                     </button>
                 </div>


### PR DESCRIPTION
💡 **What:** Added missing `aria-label` and native `title` (tooltip) attributes to several icon-only buttons across the frontend application.

🎯 **Why:** To improve accessibility for screen readers (which rely on `aria-label` for context) and provide a better experience for sighted mouse users (who benefit from native tooltips to understand icon-only actions). This addresses findings noted in `.jules/palette.md`.

📸 **Before/After:** The buttons visibly look the same, but now expose tooltips on hover and provide correct context for assistive technology.

♿ **Accessibility:** Fixed missing accessibility roles on critical interactive elements like modal close buttons, data refresh toggles, theme switchers, and floating action buttons across `BrandPage`, `SalesCartPage`, `MarketingPage`, and `ThemeToggle`.

---
*PR created automatically by Jules for task [9556777748861782187](https://jules.google.com/task/9556777748861782187) started by @info-vin*