### PR TITLE
⚡ Bolt: Batch project sources database fetch

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 ## 2025-05-18 - Tracking O(N) generator expressions in Python queues for rate limiters
 **Learning:** In highly concurrent paths like `RateLimiter`, using an O(N) generator expression (e.g., `sum(tokens for _, tokens in deque)`) to calculate current token usage causes a significant performance bottleneck because it repeatedly loops over potentially thousands of items.
 **Action:** Replace `sum(...)` generator expressions over queues with an O(1) caching counter (e.g., `self.current_tokens`) that is incremented when adding items and decremented when removing items.
+
+## 2025-05-18 - Batch database fetches for related entities using .in_()
+**Learning:** Using O(N) individual database queries through loop mechanisms like `asyncio.gather(*[format_with_sources(p) for p in projects])` produces an N+1 query bottleneck when looking up relationships, such as linked sources for project IDs.
+**Action:** Always batch these database lookups into a single O(1) `.in_("id", id_list)` database query, and map the bulk response data back to the entity list in memory in order to speed up the loop processing execution path.

--- a/python/src/server/services/projects/source_linking_service.py
+++ b/python/src/server/services/projects/source_linking_service.py
@@ -105,9 +105,48 @@ class SourceLinkingService(BaseRepository):
 
     async def format_projects_with_sources(self, projects: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """
-        Enriches a list of projects with their linked sources.
+        Enriches a list of projects with their linked sources using a single batch query.
         """
-        import asyncio
+        if not projects:
+            return projects
 
-        tasks = [self.format_project_with_sources(p) for p in projects]
-        return await asyncio.gather(*tasks)
+        project_ids = [p["id"] for p in projects if p.get("id")]
+        if not project_ids:
+            for p in projects:
+                p["technical_sources"] = []
+                p["business_sources"] = []
+            return projects
+
+        def _query():
+            return (
+                self.supabase_client.table("archon_project_sources")
+                .select("project_id, source_id, notes")
+                .in_("project_id", project_ids)
+                .execute()
+            )
+
+        success, result = self.execute_query(_query, "Failed to fetch batched project sources")
+
+        for p in projects:
+            p["technical_sources"] = []
+            p["business_sources"] = []
+
+        if success:
+            sources = result.get("data", [])
+            tech_sources_map = {}
+            biz_sources_map = {}
+            for s in sources:
+                pid = s["project_id"]
+                sid = s["source_id"]
+                if s.get("notes") == "technical":
+                    tech_sources_map.setdefault(pid, []).append(sid)
+                elif s.get("notes") == "business":
+                    biz_sources_map.setdefault(pid, []).append(sid)
+
+            for p in projects:
+                pid = p.get("id")
+                if pid:
+                    p["technical_sources"] = tech_sources_map.get(pid, [])
+                    p["business_sources"] = biz_sources_map.get(pid, [])
+
+        return projects


### PR DESCRIPTION
💡 What: The optimization implemented replaces an O(N) database query bottleneck involving `asyncio.gather` within a loop with a single O(1) query using `.in_("project_id", project_ids)` in `format_projects_with_sources`.
🎯 Why: Iterating over multiple projects and calling `format_project_with_sources` for each creates an N+1 query problem, making repeated calls to the `archon_project_sources` table and severely reducing execution speed for long lists of projects. 
📊 Impact: Reduces database calls from O(N) to O(1) when fetching linked technical and business sources, removing a massive performance bottleneck on project endpoints.
🔬 Measurement: Verified with `pytest` suite ensuring backward-compatible mapping logic, which passes successfully under full integration conditions.

---
*PR created automatically by Jules for task [4022172911997966344](https://jules.google.com/task/4022172911997966344) started by @info-vin*