### PR TITLE
🎨 Palette: Add dynamic ARIA label to chat reconnect button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-05-14 - Adding ARIA labels to grouped icon-only buttons
 **Learning:** Icon-only buttons lacking `aria-label`s fail to convey their purpose to screen reader users. When these buttons act as a group (e.g., action buttons for a task), wrapping them in an element with `role="group"` and an `aria-label` provides crucial context.
 **Action:** Always add `aria-label` to icon-only buttons. If they are logically grouped, enclose them in a container with `role="group"` and an `aria-label`.
+
+## 2026-04-02 - [Dynamic ARIA labels for loading states]
+**Learning:** Screen readers might not correctly announce the changing state of a button if its inner text changes during async operations (like from 'Reconnect' to 'Connecting...').
+**Action:** Always provide a dynamic `aria-label` that reflects the current loading state of the button.

--- a/archon-ui-main/src/components/agent-chat/ArchonChatPanel.tsx
+++ b/archon-ui-main/src/components/agent-chat/ArchonChatPanel.tsx
@@ -278,6 +278,7 @@ export const ArchonChatPanel: React.FC<ArchonChatPanelProps> = props => {
                 <button
                   onClick={handleReconnect}
                   disabled={isReconnecting}
+                  aria-label={isReconnecting ? 'Reconnecting to chat server' : 'Reconnect to chat server'}
                   className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 bg-blue-100/80 hover:bg-blue-200/80 dark:bg-blue-900/30 dark:hover:bg-blue-800/40 px-2 py-1 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   <RefreshCw className={`w-3 h-3 ${isReconnecting ? 'animate-spin' : ''}`} />


### PR DESCRIPTION
💡 What: Added a dynamic `aria-label` to the reconnect button in `ArchonChatPanel.tsx` that updates based on the loading state (`isReconnecting`).
🎯 Why: Screen readers might read static text for buttons that dynamically change content. This ensures the correct, current state ("Connecting..." vs "Reconnect") is communicated to visually impaired users.
📸 Before/After: Visual snapshot of the "Reconnect" state and "Connecting..." state captured and verified.
♿ Accessibility: Improves dynamic state announcements for screen readers.

---
*PR created automatically by Jules for task [11903782745738219081](https://jules.google.com/task/11903782745738219081) started by @info-vin*