### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/archon-ui-main/src/features/rag-settings/components/APIKeysSection.tsx
+++ b/archon-ui-main/src/features/rag-settings/components/APIKeysSection.tsx
@@ -281,6 +281,7 @@ export const APIKeysSection = () => {
                       type="button"
                       onClick={() => toggleValueVisibility(index)}
                       disabled={cred.isFromBackend && cred.is_encrypted && cred.value === '[ENCRYPTED]'}
+                      aria-label={cred.showValue ? "Hide value" : "Show value"}
                       className={`absolute right-10 top-1/2 -translate-y-1/2 p-1.5 rounded transition-colors ${
                         cred.isFromBackend && cred.is_encrypted && cred.value === '[ENCRYPTED]'
                           ? 'cursor-not-allowed opacity-50'
@@ -304,6 +305,7 @@ export const APIKeysSection = () => {
                       type="button"
                       onClick={() => toggleEncryption(index)}
                       disabled={cred.isFromBackend && cred.is_encrypted && cred.value === '[ENCRYPTED]'}
+                      aria-label={cred.is_encrypted ? "Decrypt credential" : "Encrypt credential"}
                       className={`
                         absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded transition-colors
                         ${
@@ -333,6 +335,7 @@ export const APIKeysSection = () => {
                 <div className="flex items-center justify-center">
                   <button
                     onClick={() => deleteCredential(index)}
+                    aria-label="Delete credential"
                     className="p-1 rounded text-gray-400 hover:text-red-600 transition-colors"
                     title="Delete credential"
                   >

--- a/archon-ui-main/src/features/rag-settings/components/OllamaModelSelectionModal.tsx
+++ b/archon-ui-main/src/features/rag-settings/components/OllamaModelSelectionModal.tsx
@@ -171,7 +171,7 @@ export const OllamaModelSelectionModal: React.FC<OllamaModelSelectionModalProps>
           <div><h2 className="text-xl font-semibold text-white flex items-center"><Zap className="w-5 h-5 text-blue-400 mr-2" />Select Ollama Model</h2><p className="text-sm text-gray-400 mt-1">Choose model for {modelType} from {selectedInstanceUrl}</p></div>
           <div className="flex items-center gap-2">
             <Button variant="outline" size="sm" onClick={refreshModels} disabled={refreshing} className="text-blue-400 border-blue-400"><RotateCcw className={`w-4 h-4 mr-1 ${refreshing ? 'animate-spin' : ''}`} />Refresh</Button>
-            <button onClick={onClose} className="text-gray-400 hover:text-white"><X className="w-6 h-6" /></button>
+            <button aria-label="Close modal" onClick={onClose} className="text-gray-400 hover:text-white"><X className="w-6 h-6" /></button>
           </div>
         </div>
         <div className="p-6 border-b border-gray-700">

--- a/archon-ui-main/src/features/rag-settings/components/sections/ProviderGrid.tsx
+++ b/archon-ui-main/src/features/rag-settings/components/sections/ProviderGrid.tsx
@@ -90,6 +90,7 @@ export const ProviderGrid: React.FC<ProviderGridProps> = ({
             <button
               key={provider.key}
               type="button"
+              aria-label={`Select ${provider.name} provider`}
               onClick={() => {
                 const providerKey = provider.key as ProviderKey;
                 if (activeSelection === 'chat') {


### PR DESCRIPTION
💡 **What:** Added descriptive and dynamic `aria-label` attributes to icon-only buttons across three components (`APIKeysSection.tsx`, `OllamaModelSelectionModal.tsx`, and `ProviderGrid.tsx`).

🎯 **Why:** Icon-only buttons lacking accessible names are announced as just "button" by screen readers, making them unusable for visually impaired users. Adding `aria-label` ensures the purpose and current state of the button are correctly conveyed.

📸 **Before/After:** Not a visual change.

♿ **Accessibility:**
- Added `aria-label="Close modal"` to the 'X' modal close button.
- Added dynamic `aria-label` attributes (e.g. "Hide value" / "Show value") to API key visibility and encryption toggles.
- Added `aria-label="Delete credential"` to trash icons.
- Added dynamic `aria-label` attributes reflecting the selection intent for AI provider grid buttons.

---
*PR created automatically by Jules for task [17686779758671261418](https://jules.google.com/task/17686779758671261418) started by @info-vin*