### PR TITLE
🎨 Palette: Add loading state to TaskModal submit button

### DIFF
--- a/enduser-ui-fe/src/components/TaskModal.tsx
+++ b/enduser-ui-fe/src/components/TaskModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { AssignableUser, Task, TaskPriority, NewTaskData, UpdateTaskData } from '../types.ts';
 import { api } from '../services/api';
-import { XIcon, SparklesIcon } from './Icons.tsx';
+import { XIcon, SparklesIcon, RefreshCwIcon } from './Icons.tsx';
 import { KnowledgeSelector } from './KnowledgeSelector.tsx';
 import { MobileDateTimePicker } from './common/MobileDateTimePicker';
 
@@ -416,7 +416,8 @@ export const TaskModal: React.FC<TaskModalProps> = ({ task, onClose, onTaskCreat
               <button type="button" onClick={onClose} className="px-4 py-2 rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80">
                 Cancel
               </button>
-              <button type="submit" disabled={isSubmitting} className="px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50">
+              <button type="submit" disabled={isSubmitting} className="px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 flex items-center justify-center gap-2">
+                {isSubmitting && <RefreshCwIcon className="w-4 h-4 animate-spin" />}
                 {isSubmitting ? 'Saving...' : (isEditMode ? 'Save Changes' : 'Create Task')}
               </button>
             </div>


### PR DESCRIPTION
**💡 What:** Added a `RefreshCwIcon` with a spin animation to the primary submit button in the `TaskModal` component.

**🎯 Why:** Previously, when a user submitted a task, the button would simply say "Saving..." and become disabled. Adding a spinner provides clearer, immediate visual feedback that a background process is active, improving user confidence.

**📸 Before/After:** See the attached verification screenshot for the updated button state.

**♿ Accessibility:** Enhanced the disabled state clarity for the primary action button.

---
*PR created automatically by Jules for task [2145089773907534952](https://jules.google.com/task/2145089773907534952) started by @info-vin*