### PR TITLE
🎨 Palette: Add dynamic ARIA labels to modal submit buttons

### DIFF
--- a/enduser-ui-fe/src/components/ProjectModal.tsx
+++ b/enduser-ui-fe/src/components/ProjectModal.tsx
@@ -79,6 +79,7 @@ export const ProjectModal: React.FC<ProjectModalProps> = ({ onClose, onProjectCr
               type="submit"
               className="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50"
               disabled={isSubmitting}
+              aria-label={isSubmitting ? 'Creating project...' : 'Create project'}
             >
               {isSubmitting ? 'Creating...' : 'Create Project'}
             </button>

--- a/enduser-ui-fe/src/components/TaskModal.test.tsx
+++ b/enduser-ui-fe/src/components/TaskModal.test.tsx
@@ -63,7 +63,7 @@ describe('TaskModal', () => {
     setup();
     expect(screen.getByText('Create New Task')).toBeInTheDocument();
     expect(screen.getByLabelText('Title')).toHaveValue('');
-    expect(screen.getByRole('button', { name: 'Create Task' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create task' })).toBeInTheDocument();
     // Wait for users to load
     await screen.findByRole('option', { name: 'Alice Johnson' });
     await screen.findByRole('option', { name: '(AI) Assistant' });
@@ -113,7 +113,7 @@ describe('TaskModal', () => {
     // Mock window.alert
     const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
 
-    await user.click(screen.getByRole('button', { name: 'Create Task' }));
+    await user.click(screen.getByRole('button', { name: 'Create task' }));
 
     await waitFor(() => {
       expect(alertSpy).toHaveBeenCalled();
@@ -138,7 +138,7 @@ describe('TaskModal', () => {
     // Mock window.alert
     const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
 
-    await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+    await user.click(screen.getByRole('button', { name: 'Save changes' }));
 
     await waitFor(() => {
       expect(onTaskUpdated).toHaveBeenCalledTimes(1);
@@ -153,7 +153,7 @@ describe('TaskModal', () => {
     const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
     setup({ onTaskCreated });
 
-    const submitButton = screen.getByRole('button', { name: 'Create Task' });
+    const submitButton = screen.getByRole('button', { name: 'Create task' });
     fireEvent.submit(submitButton);
 
     await waitFor(() => {

--- a/enduser-ui-fe/src/components/TaskModal.tsx
+++ b/enduser-ui-fe/src/components/TaskModal.tsx
@@ -416,7 +416,7 @@ export const TaskModal: React.FC<TaskModalProps> = ({ task, onClose, onTaskCreat
               <button type="button" onClick={onClose} className="px-4 py-2 rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80">
                 Cancel
               </button>
-              <button type="submit" disabled={isSubmitting} className="px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 flex items-center justify-center gap-2">
+              <button type="submit" disabled={isSubmitting} className="px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 flex items-center justify-center gap-2" aria-label={isSubmitting ? 'Saving task...' : (isEditMode ? 'Save changes' : 'Create task')}>
                 {isSubmitting && <RefreshCwIcon className="w-4 h-4 animate-spin" />}
                 {isSubmitting ? 'Saving...' : (isEditMode ? 'Save Changes' : 'Create Task')}
               </button>


### PR DESCRIPTION
💡 What: Added dynamic `aria-label` attributes to the submit buttons in `TaskModal.tsx` and `ProjectModal.tsx`.
🎯 Why: To ensure screen readers accurately announce the loading state of the buttons during asynchronous submit operations, rather than a static label.
📸 Before/After: Covered by Playwright verification screenshots.
♿ Accessibility: Improved screen reader feedback for interactive forms during submission processing. Also updated testing coverage to reflect the new dynamic labels.

---
*PR created automatically by Jules for task [7715454996633117420](https://jules.google.com/task/7715454996633117420) started by @info-vin*