### PR TITLE
🎨 Palette: Add ARIA label to ActiveForce member details button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2026-04-02 - [Dynamic ARIA labels for loading states]
 **Learning:** Screen readers might not correctly announce the changing state of a button if its inner text changes during async operations (like from 'Reconnect' to 'Connecting...').
 **Action:** Always provide a dynamic `aria-label` that reflects the current loading state of the button.
+
+## 2025-03-05 - ActiveForce Member Details Button Accessibility
+**Learning:** Icon-only buttons used for viewing specific item details (like team members) need dynamic ARIA labels that include the item's name (e.g., `aria-label={\`View details for \${member.name}\`}`) to provide adequate context for screen reader users, rather than a generic "View details".
+**Action:** Always use dynamic interpolation for `aria-label`s on icon-only buttons within mapped lists to ensure context-specific accessibility.

--- a/enduser-ui-fe/src/features/manager/components/ActiveForce.tsx
+++ b/enduser-ui-fe/src/features/manager/components/ActiveForce.tsx
@@ -109,6 +109,7 @@ export const ActiveForce: React.FC<ActiveForceProps> = ({
                         <button 
                             onClick={() => setSelectedMember(member)}
                             className="p-2 text-gray-400 hover:text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors"
+                            aria-label={`View details for ${member.name}`}
                         >
                             <SearchIcon className="w-4 h-4" />
                         </button>


### PR DESCRIPTION
💡 What: Added a dynamic `aria-label` to the icon-only search button in the ActiveForce member list.
🎯 Why: To provide screen reader users with context about which member's details will be viewed.
📸 Before/After: (None needed, code-only a11y change)
♿ Accessibility: Improved screen reader experience for the ActiveForce dashboard component by adding an explicit, descriptive accessible name to an icon-only button.

---
*PR created automatically by Jules for task [302042097493664682](https://jules.google.com/task/302042097493664682) started by @info-vin*