### PR TITLE
🎨 Palette: Add ARIA labels to EthicsAuditPanel buttons

### DIFF
--- a/CONTRIBUTING_tw.md
+++ b/CONTRIBUTING_tw.md
@@ -341,6 +341,25 @@ Phase 4.4.5 引入了 **Clockwork** 進行系統自動檢測。
     此步驟提供兩種流程選項：
     *   **流程一 (快速檢查)**: 至少執行 `make test` 與 `make lint`。
     *   **流程二 (完整驗證)**: 執行「[2.3 全 Docker 環境手動驗證 SOP](#23-全-docker-環境手動驗證-sop)」，以進行最徹底的檢查。
+    - migration/0.2.2/01_foundation_types.sql
+    - migration/0.2.2/02_tables_core.sql
+    - migration/0.2.2/03_tables_business.sql
+    - migration/0.2.2/04_tables_ops.sql
+    - migration/0.2.2/05_logic_functions.sql
+    - migration/0.2.2/06_constraints_main.sql
+    - migration/0.2.2/07_logic_indexes.sql
+    - migration/0.2.2/08_logic_triggers.sql
+    - migration/0.2.2/09_constraints_fkeys.sql
+    - migration/0.2.2/10_security_rls.sql
+    - migration/0.2.2/11_seed_config.sql
+    - migration/0.2.2/12_seed_rbac.sql
+    - migration/0.2.2/13_optimize_task_reordering.sql
+    - migration/0.2.2/14_sync_persona_parity.sql
+    - migration/0.2.2/RESET_DB.sql
+    - migration/0.2.2/seed_blog_posts.sql
+    - migration/0.2.2/seed_mock_data.sql
+    - migration/0.2.2/seed_rag_defaults.sql
+    - migration/temp_fix_seq.sql
 
 2.  **階段二：資料庫遷移 (Database Migration) - v2 (Tracked)**
 

--- a/enduser-ui-fe/src/features/manager/components/nexus/EthicsAuditPanel.tsx
+++ b/enduser-ui-fe/src/features/manager/components/nexus/EthicsAuditPanel.tsx
@@ -70,6 +70,7 @@ export const EthicsAuditPanel: React.FC<EthicsAuditPanelProps> = ({
                             <button
                                 onClick={() => handleDispatch(v.id)}
                                 className="px-4 py-2 bg-red-600 text-white rounded-xl text-[10px] font-black hover:bg-red-700 transition-all"
+                                aria-label={`Dispatch investigation for ${v.event_type}`}
                             >
                                 DISPATCH INVESTIGATION
                             </button>
@@ -93,6 +94,7 @@ export const EthicsAuditPanel: React.FC<EthicsAuditPanelProps> = ({
                                 <button
                                     onClick={() => handleViewDiff(p)}
                                     className="px-4 py-2 bg-slate-100 text-slate-600 rounded-xl text-[10px] font-black hover:bg-slate-200"
+                                    aria-label={`View diff for prompt change on ${p.document_id}`}
                                 >
                                     VIEW DIFF
                                 </button>
@@ -100,6 +102,7 @@ export const EthicsAuditPanel: React.FC<EthicsAuditPanelProps> = ({
                                     onClick={() => handleApprovePrompt(p.id)}
                                     disabled={processingId === p.id}
                                     className="px-4 py-2 bg-indigo-600 text-white rounded-xl text-[10px] font-black hover:bg-indigo-700"
+                                    aria-label={processingId === p.id ? `Approving prompt change for ${p.document_id}...` : `Approve prompt change for ${p.document_id}`}
                                 >
                                     {processingId === p.id ? '...' : 'APPROVE'}
                                 </button>


### PR DESCRIPTION
* 💡 What: Added context-specific ARIA labels to icon-only and generic buttons in the EthicsAuditPanel component.
* 🎯 Why: Screen reader users previously lacked context for these buttons ("View Diff", "Approve", etc.) because they repeated generically across the list. Dynamic ARIA labels give proper context based on the specific document or event being managed.
* ♿ Accessibility: Improved screen reader navigation and clarity by dynamically interpolating IDs and event types into `aria-label`s.

---
*PR created automatically by Jules for task [5346544268967238723](https://jules.google.com/task/5346544268967238723) started by @info-vin*