### PR TITLE
⚡ Bolt: Batch database chunk inserts in LibrarianService

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -43,3 +43,7 @@
 ## 2024-05-18 - Beware Supabase 1000-row limit for aggregate counts
 **Learning:** Using an O(1) `.in_("id", ids)` fetch to retrieve ALL rows into memory in Python to emulate a `GROUP BY COUNT` is functionally dangerous because Supabase/PostgREST enforces a strict 1000-row limit by default. If the total relations exceed this, the query silently truncates, resulting in wildly inaccurate counts.
 **Action:** Do NOT use `.in_()` to pull raw rows to emulate aggregate database counts. Use `count="exact", head=True` inside individual `.eq()` lookups if an RPC is not available, as it delegates the true count to the database engine and respects pagination limits.
+
+## 2025-05-18 - Batching database inserts for chunked content
+**Learning:** When splitting large text files into chunks for database storage, inserting each chunk in a loop (`.insert().execute()`) creates an N+1 query bottleneck. The database insertion overhead can dominate the function's execution time for large files.
+**Action:** Batch multiple Supabase row insertions by accumulating data into a list and calling a single `.insert([...]).execute()`. Add a fallback to individual insertions in case of batch failure to preserve data and detailed logging.

--- a/python/src/server/services/librarian_service.py
+++ b/python/src/server/services/librarian_service.py
@@ -301,6 +301,7 @@ class LibrarianService:
             # 4. Content & Embedding
             chunk_size = 4000
             chunks = [content[i : i + chunk_size] for i in range(0, len(content), chunk_size)]
+            page_data_list = []
 
             for i, chunk in enumerate(chunks):
                 try:
@@ -322,7 +323,18 @@ class LibrarianService:
                         "title": f"{title} (Part {i + 1})",
                     },
                 }
-                self.supabase.table("archon_crawled_pages").insert(page_data).execute()
+                page_data_list.append(page_data)
+
+            if page_data_list:
+                try:
+                    self.supabase.table("archon_crawled_pages").insert(page_data_list).execute()
+                except Exception as batch_e:
+                    logger.warning(f"Librarian: Batch insert failed ({batch_e}), falling back to individual inserts")
+                    for p in page_data_list:
+                        try:
+                            self.supabase.table("archon_crawled_pages").insert(p).execute()
+                        except Exception as e:
+                            logger.error(f"Librarian: Individual insert failed for chunk {p['chunk_number']} of {source_id}: {e}")
 
             # 5. Record version for audit trail (Admin Insight)
             try:


### PR DESCRIPTION
💡 What: Updated `archive_file` in `python/src/server/services/librarian_service.py` to accumulate `archon_crawled_pages` chunks into a list and execute a single batch `.insert()` operation, instead of calling `.insert()` individually in a loop. It falls back to individual inserts if the batch operation fails.

🎯 Why: To solve an N+1 query problem during document ingestion. Inserting chunks individually in a loop incurs significant network and database transaction overhead per document, dominating execution time.

📊 Impact: Reduces network trips and database transactions from N to 1 during chunk insertions, significantly improving `archive_file` performance for large documents.

🔬 Measurement: Review logging and execution time when archiving large files containing many chunks.

---
*PR created automatically by Jules for task [11411107762518409261](https://jules.google.com/task/11411107762518409261) started by @info-vin*