### PR TITLE
🎨 Palette: Add aria-labels to icon-only buttons in VisitLogModal

### DIFF
--- a/enduser-ui-fe/src/features/marketing/components/VisitLogModal.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/VisitLogModal.tsx
@@ -158,7 +158,7 @@ export const VisitLogModal: React.FC<VisitLogModalProps> = ({ onClose, onSuccess
                                 <div className={`flex-1 p-3 rounded-lg border ${location ? 'bg-green-50 border-green-200 text-green-800' : 'bg-gray-50 border-gray-200 text-gray-500'}`}>
                                     {location ? `${location.lat.toFixed(4)}, ${location.lng.toFixed(4)}` : "No location data"}
                                 </div>
-                                <button onClick={handleLocation} className="p-3 bg-gray-100 rounded-lg hover:bg-gray-200 text-gray-700">
+                                <button onClick={handleLocation} aria-label="Get current location" className="p-3 bg-gray-100 rounded-lg hover:bg-gray-200 text-gray-700">
                                     <MapPinIcon className="w-5 h-5" />
                                 </button>
                             </div>
@@ -199,7 +199,7 @@ export const VisitLogModal: React.FC<VisitLogModalProps> = ({ onClose, onSuccess
                                         <p className="text-sm font-bold text-gray-800 truncate">{audioFile?.name}</p>
                                         <p className="text-xs text-gray-500">Ready to upload</p>
                                     </div>
-                                    <button onClick={clearAudio} className="p-2 hover:bg-red-100 rounded-full text-red-500 transition-colors">
+                                    <button onClick={clearAudio} aria-label="Remove audio log" className="p-2 hover:bg-red-100 rounded-full text-red-500 transition-colors">
                                         <TrashIcon className="w-4 h-4" />
                                     </button>
                                 </div>


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to the map location and remove audio buttons in the `VisitLogModal` component.
🎯 Why: Icon-only buttons without text content are invisible to screen readers, making it difficult for visually impaired users to understand their purpose. These labels provide the necessary context.
📸 Before/After: (Verified locally via Playwright screenshots during development)
♿ Accessibility: Improves WCAG compliance by ensuring interactive elements have accessible names.

---
*PR created automatically by Jules for task [3046237637919568146](https://jules.google.com/task/3046237637919568146) started by @info-vin*