### PR TITLE
🎨 Palette: [UX improvement] Add ARIA label to modal close button

### DIFF
--- a/archon-ui-main/src/features/rag-settings/components/OllamaModelSelectionModal.tsx
+++ b/archon-ui-main/src/features/rag-settings/components/OllamaModelSelectionModal.tsx
@@ -171,7 +171,7 @@ export const OllamaModelSelectionModal: React.FC<OllamaModelSelectionModalProps>
           <div><h2 className="text-xl font-semibold text-white flex items-center"><Zap className="w-5 h-5 text-blue-400 mr-2" />Select Ollama Model</h2><p className="text-sm text-gray-400 mt-1">Choose model for {modelType} from {selectedInstanceUrl}</p></div>
           <div className="flex items-center gap-2">
             <Button variant="outline" size="sm" onClick={refreshModels} disabled={refreshing} className="text-blue-400 border-blue-400"><RotateCcw className={`w-4 h-4 mr-1 ${refreshing ? 'animate-spin' : ''}`} />Refresh</Button>
-            <button onClick={onClose} className="text-gray-400 hover:text-white"><X className="w-6 h-6" /></button>
+            <button onClick={onClose} aria-label="Close modal" className="text-gray-400 hover:text-white"><X className="w-6 h-6" /></button>
           </div>
         </div>
         <div className="p-6 border-b border-gray-700">


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add ARIA label to modal close button

💡 **What:** Added `aria-label="Close modal"` to the icon-only close button (`<X />`) in the `OllamaModelSelectionModal` component.
🎯 **Why:** Icon-only buttons lacking `aria-label`s fail to convey their purpose to screen reader users. Adding this label provides crucial context and improves overall accessibility.
♿ **Accessibility:** Enhances screen reader support by ensuring the close action is explicitly announced, rather than just "button".

Verified with `pnpm lint` and `pnpm test` in `archon-ui-main`.

---
*PR created automatically by Jules for task [17460115357087661549](https://jules.google.com/task/17460115357087661549) started by @info-vin*