### PR TITLE
🎨 Palette: Add ARIA labels to permission toggles in IdentityMatrix

### DIFF
--- a/enduser-ui-fe/src/features/admin/components/IdentityMatrix.tsx
+++ b/enduser-ui-fe/src/features/admin/components/IdentityMatrix.tsx
@@ -127,6 +127,7 @@ const EditUserModal: React.FC<{ user: Employee; onClose: () => void; onSave: (up
                                     <button 
                                         key={perm}
                                         onClick={() => togglePermission(perm)}
+                                        aria-label={`Toggle override for ${perm}`}
                                         className={`flex flex-col p-2 rounded-xl border transition-all text-left group ${bgClass} hover:ring-2 ring-primary/20`}
                                     >
                                         <div className="flex justify-between items-center">
@@ -432,6 +433,7 @@ export const IdentityMatrix: React.FC = () => {
                                                 <td key={`${row.role}-${perm}`} className="px-4 py-3 text-center">
                                                     <button 
                                                         onClick={() => toggleMatrixPermission(row.role, perm)}
+                                                        aria-label={`Toggle ${perm} permission for ${row.role}`}
                                                         className={`w-6 h-6 rounded-md border flex items-center justify-center mx-auto transition-all ${hasPerm ? 'bg-green-500 border-green-600 text-white' : 'bg-background border-border text-transparent hover:border-primary/50'}`}
                                                     >
                                                         {hasPerm && <CheckCircleIcon className="w-4 h-4" />}


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to the permission toggle buttons in `IdentityMatrix.tsx`.
🎯 **Why**: The icon-only buttons for toggling role permissions and user overrides lacked accessible names. This made it difficult for users relying on screen readers to understand the purpose of the buttons.
📸 **Before/After**: N/A (Non-visual DOM change)
♿ **Accessibility**: Improved screen reader context by providing descriptive labels (e.g., "Toggle {perm} permission for {role}").

---
*PR created automatically by Jules for task [9546517651324049839](https://jules.google.com/task/9546517651324049839) started by @info-vin*