### PR TITLE
🎨 Palette: Improve Brand Page button accessibility

### DIFF
--- a/enduser-ui-fe/src/pages/BrandPage.tsx
+++ b/enduser-ui-fe/src/pages/BrandPage.tsx
@@ -6,7 +6,7 @@ import { BrandDashboardView } from '../features/marketing/components/BrandDashbo
 import { BrandWorkbenchView } from '../features/marketing/components/BrandWorkbenchView';
 import { useNavigate } from 'react-router-dom';
 import { 
-    PaletteIcon, LayoutIcon, RefreshCwIcon, SparklesIcon
+    PaletteIcon, LayoutIcon, RefreshCwIcon, SparklesIcon, XIcon
 } from '../components/Icons';
 
 const BrandPage: React.FC = () => {
@@ -82,7 +82,7 @@ const BrandPage: React.FC = () => {
                     </div>
                     
                     <div className="flex items-center gap-3">
-                        <button onClick={loadData} className="p-2 hover:bg-gray-100 dark:hover:bg-slate-800 rounded-full transition-colors">
+                        <button onClick={loadData} aria-label="Refresh brand data" className="p-2 hover:bg-gray-100 dark:hover:bg-slate-800 rounded-full transition-colors">
                             <RefreshCwIcon className={`w-5 h-5 text-slate-400 ${loading ? 'animate-spin' : ''}`} />
                         </button>
                     </div>
@@ -135,7 +135,7 @@ const BrandPage: React.FC = () => {
                             <h3 className="text-2xl font-bold text-gray-800 dark:text-white">
                                 {editingPost ? 'Edit Asset' : 'New Asset'}
                             </h3>
-                            <button onClick={() => setIsPostModalOpen(false)} className="text-gray-400 hover:text-gray-600 transition-colors">✕</button>
+                            <button onClick={() => setIsPostModalOpen(false)} aria-label="Close modal" className="text-gray-400 hover:text-gray-600 transition-colors"><XIcon className="w-5 h-5" /></button>
                         </div>
                         <CreatePostForm 
                             post={editingPost} 


### PR DESCRIPTION
💡 **What**: Added `aria-label` to the 'Refresh brand data' button and updated the 'Close modal' button to use `XIcon` with a proper `aria-label` in `BrandPage.tsx`.
🎯 **Why**: To improve accessibility for screen readers on icon-only buttons, allowing users to better navigate the modal and data refresh actions.
📸 **Before/After**: Visually verified the close modal is now a unified icon.
♿ **Accessibility**: Enhanced accessibility by replacing a hardcoded text character ('✕') with an SVG icon and adding semantic labels (`aria-label`) to buttons.

---
*PR created automatically by Jules for task [8782240154227051265](https://jules.google.com/task/8782240154227051265) started by @info-vin*