### PR TITLE
🎨 Palette: [UX improvement] - Improve modal close button accessibility in BrandPage

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,7 @@
 ## 2025-03-05 - ActiveForce Member Details Button Accessibility
 **Learning:** Icon-only buttons used for viewing specific item details (like team members) need dynamic ARIA labels that include the item's name (e.g., `aria-label={\`View details for \${member.name}\`}`) to provide adequate context for screen reader users, rather than a generic "View details".
 **Action:** Always use dynamic interpolation for `aria-label`s on icon-only buttons within mapped lists to ensure context-specific accessibility.
+
+## 2024-04-22 - Replacing Hardcoded Text Icons with Proper SVG Components
+**Learning:** Hardcoded text characters (like `✕` for close buttons) not only look inconsistent across different OS and fonts, but they also severely harm accessibility if lacking an `aria-label`. Screen readers may read out the literal character name (e.g., "multiplication x"), which is confusing.
+**Action:** When creating or fixing modal close buttons, always use existing SVG icon components (like `<XIcon />`) from the design system, and explicitly attach a descriptive `aria-label` (e.g., `aria-label="Close modal"`) to ensure the intent is clearly communicated to assistive technologies.

--- a/enduser-ui-fe/src/pages/BrandPage.tsx
+++ b/enduser-ui-fe/src/pages/BrandPage.tsx
@@ -6,7 +6,7 @@ import { BrandDashboardView } from '../features/marketing/components/BrandDashbo
 import { BrandWorkbenchView } from '../features/marketing/components/BrandWorkbenchView';
 import { useNavigate } from 'react-router-dom';
 import { 
-    PaletteIcon, LayoutIcon, RefreshCwIcon, SparklesIcon
+    PaletteIcon, LayoutIcon, RefreshCwIcon, SparklesIcon, XIcon
 } from '../components/Icons';
 
 const BrandPage: React.FC = () => {
@@ -135,7 +135,7 @@ const BrandPage: React.FC = () => {
                             <h3 className="text-2xl font-bold text-gray-800 dark:text-white">
                                 {editingPost ? 'Edit Asset' : 'New Asset'}
                             </h3>
-                            <button onClick={() => setIsPostModalOpen(false)} className="text-gray-400 hover:text-gray-600 transition-colors">✕</button>
+                            <button onClick={() => setIsPostModalOpen(false)} className="text-gray-400 hover:text-gray-600 transition-colors" aria-label="Close modal"><XIcon className="w-5 h-5" /></button>
                         </div>
                         <CreatePostForm 
                             post={editingPost} 


### PR DESCRIPTION
💡 **What:** Replaced the hardcoded `✕` text character used for the modal close button in `BrandPage.tsx` with the `<XIcon />` component from the design system, and added an `aria-label="Close modal"` attribute.
🎯 **Why:** Using a text character for an icon causes visual inconsistencies across operating systems and fonts. More importantly, without an `aria-label`, screen readers might read it confusingly (e.g., "multiplication x"). Using a proper SVG component and an explicit `aria-label` makes the UI more consistent and accessible.
📸 **Before/After:** The button now renders a consistent SVG instead of text, and is readable by screen readers as "Close modal".
♿ **Accessibility:** Added an `aria-label` to clearly communicate the button's purpose to assistive technologies.

---
*PR created automatically by Jules for task [9513797656074045520](https://jules.google.com/task/9513797656074045520) started by @info-vin*