### PR TITLE
🎨 Palette: Add missing aria-labels to icon-only buttons

### DIFF
--- a/CONTRIBUTING_tw.md
+++ b/CONTRIBUTING_tw.md
@@ -344,6 +344,28 @@ Phase 4.4.5 引入了 **Clockwork** 進行系統自動檢測。
 
 2.  **階段二：資料庫遷移 (Database Migration) - v2 (Tracked)**
 
+    **New migrations (detected today):**
+    * migration/0.2.2/01_foundation_types.sql
+    * migration/0.2.2/02_tables_core.sql
+    * migration/0.2.2/03_tables_business.sql
+    * migration/0.2.2/04_tables_ops.sql
+    * migration/0.2.2/05_logic_functions.sql
+    * migration/0.2.2/06_constraints_main.sql
+    * migration/0.2.2/07_logic_indexes.sql
+    * migration/0.2.2/08_logic_triggers.sql
+    * migration/0.2.2/09_constraints_fkeys.sql
+    * migration/0.2.2/10_security_rls.sql
+    * migration/0.2.2/11_seed_config.sql
+    * migration/0.2.2/12_seed_rbac.sql
+    * migration/0.2.2/13_optimize_task_reordering.sql
+    * migration/0.2.2/14_sync_persona_parity.sql
+    * migration/0.2.2/15_add_blog_cover_image.sql
+    * migration/0.2.2/RESET_DB.sql
+    * migration/0.2.2/seed_blog_posts.sql
+    * migration/0.2.2/seed_mock_data.sql
+    * migration/0.2.2/seed_rag_defaults.sql
+    * migration/temp_fix_seq.sql
+
     此流程的最終目標是安全、可追蹤地更新資料庫結構。
 
     **核心原則**:

--- a/enduser-ui-fe/src/features/marketing/components/BrandDashboardView.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/BrandDashboardView.tsx
@@ -192,6 +192,7 @@ export const BrandDashboardView: React.FC<BrandDashboardViewProps> = ({
                             onClick={downloadLogo}
                             className="absolute bottom-4 right-4 bg-white/10 backdrop-blur-md text-white p-2 rounded-lg hover:bg-white/20 transition-all opacity-0 group-hover:opacity-100"
                             title="Download SVG"
+                            aria-label="Download SVG"
                         >
                             <DownloadIcon className="w-5 h-5" />
                         </button>

--- a/enduser-ui-fe/src/features/marketing/components/LeadsCardStack.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/LeadsCardStack.tsx
@@ -340,6 +340,7 @@ export const LeadsCardStack: React.FC<LeadsCardStackProps> = ({ leads, onSwipeRi
                     disabled={history.length === 0}
                     className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center shadow-sm text-gray-500 hover:bg-gray-200 disabled:opacity-30 transition-all"
                     title="Undo Last Swipe"
+                    aria-label="Undo Last Swipe"
                 >
                     <RefreshCwIcon className="w-5 h-5 -scale-x-100" />
                 </button>

--- a/enduser-ui-fe/src/features/marketing/components/VisitLogModal.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/VisitLogModal.tsx
@@ -158,7 +158,7 @@ export const VisitLogModal: React.FC<VisitLogModalProps> = ({ onClose, onSuccess
                                 <div className={`flex-1 p-3 rounded-lg border ${location ? 'bg-green-50 border-green-200 text-green-800' : 'bg-gray-50 border-gray-200 text-gray-500'}`}>
                                     {location ? `${location.lat.toFixed(4)}, ${location.lng.toFixed(4)}` : "No location data"}
                                 </div>
-                                <button onClick={handleLocation} className="p-3 bg-gray-100 rounded-lg hover:bg-gray-200 text-gray-700">
+                                <button onClick={handleLocation} aria-label="Get current location" className="p-3 bg-gray-100 rounded-lg hover:bg-gray-200 text-gray-700">
                                     <MapPinIcon className="w-5 h-5" />
                                 </button>
                             </div>
@@ -199,7 +199,7 @@ export const VisitLogModal: React.FC<VisitLogModalProps> = ({ onClose, onSuccess
                                         <p className="text-sm font-bold text-gray-800 truncate">{audioFile?.name}</p>
                                         <p className="text-xs text-gray-500">Ready to upload</p>
                                     </div>
-                                    <button onClick={clearAudio} className="p-2 hover:bg-red-100 rounded-full text-red-500 transition-colors">
+                                    <button onClick={clearAudio} aria-label="Clear audio" className="p-2 hover:bg-red-100 rounded-full text-red-500 transition-colors">
                                         <TrashIcon className="w-4 h-4" />
                                     </button>
                                 </div>

--- a/enduser-ui-fe/src/pages/BrandPage.tsx
+++ b/enduser-ui-fe/src/pages/BrandPage.tsx
@@ -82,7 +82,7 @@ const BrandPage: React.FC = () => {
                     </div>
                     
                     <div className="flex items-center gap-3">
-                        <button onClick={loadData} className="p-2 hover:bg-gray-100 dark:hover:bg-slate-800 rounded-full transition-colors">
+                        <button onClick={loadData} aria-label="Refresh data" className="p-2 hover:bg-gray-100 dark:hover:bg-slate-800 rounded-full transition-colors">
                             <RefreshCwIcon className={`w-5 h-5 text-slate-400 ${loading ? 'animate-spin' : ''}`} />
                         </button>
                     </div>


### PR DESCRIPTION
## What
Added missing `aria-label` attributes to several icon-only buttons across the application (VisitLogModal, BrandDashboardView, LeadsCardStack, BrandPage) and logged new database migrations in `CONTRIBUTING_tw.md`.

## Why
Icon-only buttons without accessible names cannot be interpreted by screen readers, creating a poor experience for users relying on assistive technology. This change ensures compliance with accessibility standards (WCAG) and makes the UI more inclusive. Recording migrations follows the strict deployment standard operating procedures.

## Before/After
Before:
`<button><DownloadIcon /></button>`

After:
`<button aria-label="Download SVG"><DownloadIcon /></button>`

## Accessibility
Greatly improves screen-reader compatibility for users interacting with the brand dashboard, visit log modals, lead cards, and brand data views.

*(Note: Playwright visual verification failed due to data/auth blockers on local preview, but structural source verification was performed to confirm presence of `aria-label`s. Temporary scripts were deleted per guidelines.)*

---
*PR created automatically by Jules for task [8965351648898182884](https://jules.google.com/task/8965351648898182884) started by @info-vin*