### PR TITLE
🎨 Palette: Add aria-labels to VisitLogModal icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,6 @@
 ## 2024-04-22 - Replacing Hardcoded Text Icons with Proper SVG Components
 **Learning:** Hardcoded text characters (like `✕` for close buttons) not only look inconsistent across different OS and fonts, but they also severely harm accessibility if lacking an `aria-label`. Screen readers may read out the literal character name (e.g., "multiplication x"), which is confusing.
 **Action:** When creating or fixing modal close buttons, always use existing SVG icon components (like `<XIcon />`) from the design system, and explicitly attach a descriptive `aria-label` (e.g., `aria-label="Close modal"`) to ensure the intent is clearly communicated to assistive technologies.
+## 2024-05-15 - Adding aria-labels to VisitLogModal icon buttons
+**Learning:** Icon-only buttons used for specific actions in modals (like "Location" or "Clear Audio" in `VisitLogModal`) lack accessible names, causing screen readers to announce them as generic buttons. This prevents visually impaired users from understanding their function.
+**Action:** Always add descriptive `aria-label` attributes to icon-only buttons (e.g., `aria-label="Use current location"`) to ensure the action intent is clearly communicated to assistive technologies.

--- a/enduser-ui-fe/src/features/marketing/components/VisitLogModal.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/VisitLogModal.tsx
@@ -158,7 +158,7 @@ export const VisitLogModal: React.FC<VisitLogModalProps> = ({ onClose, onSuccess
                                 <div className={`flex-1 p-3 rounded-lg border ${location ? 'bg-green-50 border-green-200 text-green-800' : 'bg-gray-50 border-gray-200 text-gray-500'}`}>
                                     {location ? `${location.lat.toFixed(4)}, ${location.lng.toFixed(4)}` : "No location data"}
                                 </div>
-                                <button onClick={handleLocation} className="p-3 bg-gray-100 rounded-lg hover:bg-gray-200 text-gray-700">
+                                <button onClick={handleLocation} className="p-3 bg-gray-100 rounded-lg hover:bg-gray-200 text-gray-700" aria-label="Use current location">
                                     <MapPinIcon className="w-5 h-5" />
                                 </button>
                             </div>
@@ -199,7 +199,7 @@ export const VisitLogModal: React.FC<VisitLogModalProps> = ({ onClose, onSuccess
                                         <p className="text-sm font-bold text-gray-800 truncate">{audioFile?.name}</p>
                                         <p className="text-xs text-gray-500">Ready to upload</p>
                                     </div>
-                                    <button onClick={clearAudio} className="p-2 hover:bg-red-100 rounded-full text-red-500 transition-colors">
+                                    <button onClick={clearAudio} className="p-2 hover:bg-red-100 rounded-full text-red-500 transition-colors" aria-label="Remove audio recording">
                                         <TrashIcon className="w-4 h-4" />
                                     </button>
                                 </div>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the "Location" (`<MapPinIcon />`) and "Clear Audio" (`<TrashIcon />`) icon-only buttons in the `VisitLogModal`.
🎯 Why: Icon-only buttons without accessible names are announced as just "button" by screen readers, confusing users relying on assistive technologies.
📸 Before/After: (Screenshot omitted in text)
♿ Accessibility: Screen readers will now announce "Use current location" and "Remove audio recording" instead of "button".

---
*PR created automatically by Jules for task [8458818064604670661](https://jules.google.com/task/8458818064604670661) started by @info-vin*