### PR TITLE
🎨 Palette: Add ARIA labels to unlabelled buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-04-22 - Replacing Hardcoded Text Icons with Proper SVG Components
 **Learning:** Hardcoded text characters (like `✕` for close buttons) not only look inconsistent across different OS and fonts, but they also severely harm accessibility if lacking an `aria-label`. Screen readers may read out the literal character name (e.g., "multiplication x"), which is confusing.
 **Action:** When creating or fixing modal close buttons, always use existing SVG icon components (like `<XIcon />`) from the design system, and explicitly attach a descriptive `aria-label` (e.g., `aria-label="Close modal"`) to ensure the intent is clearly communicated to assistive technologies.
+
+## 2024-05-18 - Expanding Generic Component Props for Accessibility
+**Learning:** Reusable UI components like custom Checkboxes and Toggles often encapsulate standard HTML elements but omit crucial accessibility props (like `aria-label`). If a developer uses `<Checkbox />` without a visible `<label>`, screen readers have no context for what the checkbox controls.
+**Action:** Always inspect custom UI primitives to ensure they can accept and forward `aria-label` or `aria-labelledby` props. When creating generic components, include `ariaLabel?: string;` in the props interface and apply it to the underlying interactive element, ideally with a fallback if appropriate.

--- a/archon-ui-main/src/components/ui/Checkbox.tsx
+++ b/archon-ui-main/src/components/ui/Checkbox.tsx
@@ -8,6 +8,7 @@ interface CheckboxProps {
   indeterminate?: boolean;
   disabled?: boolean;
   className?: string;
+  ariaLabel?: string;
 }
 
 export const Checkbox = ({
@@ -15,7 +16,8 @@ export const Checkbox = ({
   onChange,
   indeterminate = false,
   disabled = false,
-  className = ''
+  className = '',
+  ariaLabel
 }: CheckboxProps) => {
   const [isChecked, setIsChecked] = useState(checked);
 
@@ -35,6 +37,7 @@ export const Checkbox = ({
     <button
       onClick={handleClick}
       disabled={disabled}
+      aria-label={ariaLabel || "Toggle checkbox"}
       className={`
         relative w-5 h-5 rounded-md
         bg-white/10 dark:bg-black/20

--- a/archon-ui-main/src/components/ui/GlassCrawlDepthSelector.tsx
+++ b/archon-ui-main/src/components/ui/GlassCrawlDepthSelector.tsx
@@ -72,6 +72,7 @@ export const GlassCrawlDepthSelector: React.FC<GlassCrawlDepthSelectorProps> = (
                 "flex items-center justify-center flex-shrink-0",
                 "hover:scale-110 active:scale-95"
               )}
+              aria-label={`Select crawl depth level ${level}`}
             >
               {/* Outer glass layer with glow */}
               <div className={cn(

--- a/archon-ui-main/src/components/ui/MigrationBanner.tsx
+++ b/archon-ui-main/src/components/ui/MigrationBanner.tsx
@@ -48,6 +48,7 @@ export const MigrationBanner: React.FC<MigrationBannerProps> = ({
               <button
                 onClick={onDismiss}
                 className="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-200 text-sm font-medium"
+                aria-label="Dismiss migration banner"
               >
                 Dismiss (temporarily)
               </button>

--- a/archon-ui-main/src/components/ui/Toggle.tsx
+++ b/archon-ui-main/src/components/ui/Toggle.tsx
@@ -6,20 +6,22 @@ interface ToggleProps {
   accentColor?: 'purple' | 'green' | 'pink' | 'blue' | 'orange';
   icon?: React.ReactNode;
   disabled?: boolean;
+  ariaLabel?: string;
 }
 export const Toggle: React.FC<ToggleProps> = ({
   checked,
   onCheckedChange,
   accentColor = 'blue',
   icon,
-  disabled = false
+  disabled = false,
+  ariaLabel
 }) => {
   const handleClick = () => {
     if (!disabled) {
       onCheckedChange(!checked);
     }
   };
-  return <button role="switch" aria-checked={checked} onClick={handleClick} disabled={disabled} className={`
+  return <button role="switch" aria-checked={checked} aria-label={ariaLabel || "Toggle"} onClick={handleClick} disabled={disabled} className={`
         toggle-switch
         ${checked ? 'toggle-checked' : ''}
         ${disabled ? 'toggle-disabled' : ''}

--- a/archon-ui-main/src/features/knowledge/components/KnowledgeCardTags.tsx
+++ b/archon-ui-main/src/features/knowledge/components/KnowledgeCardTags.tsx
@@ -262,6 +262,8 @@ export const KnowledgeCardTags: React.FC<KnowledgeCardTagsProps> = ({ sourceId, 
             "flex items-center gap-0.5 text-[10px] text-gray-500 dark:text-gray-400",
             "hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors px-1 py-0.5 rounded",
           ].join(" ")}
+          aria-expanded={showAllTags}
+          aria-label={showAllTags ? "Show fewer tags" : "Show more tags"}
         >
           {showAllTags ? (
             <>


### PR DESCRIPTION
### 💡 What
Added missing `aria-label` and `aria-expanded` attributes to several interactive buttons across `archon-ui-main`. Updated reusable primitive components (`Checkbox` and `Toggle`) to accept an `ariaLabel` prop.

### 🎯 Why
Screen reader users encounter these buttons as generic "button" elements without any context of their action. These changes ensure that users employing assistive technologies can understand the function of dismiss buttons, depth selectors, and form toggles.

### 📸 Before/After
There are no visual changes; these are purely HTML attribute additions for accessibility.

### ♿ Accessibility
- Added `aria-label="Dismiss migration banner"` to the `MigrationBanner` close button.
- Added dynamic `aria-label={\`Select crawl depth level \${level}\`}` to the `GlassCrawlDepthSelector` level buttons.
- Added `aria-expanded` and dynamic `aria-label` to the "Show more/less" tags toggle in `KnowledgeCardTags`.
- Extended `CheckboxProps` and `ToggleProps` to accept an `ariaLabel` and applied it to the underlying `<button>` elements, providing generic defaults.

---
*PR created automatically by Jules for task [4404779502008771928](https://jules.google.com/task/4404779502008771928) started by @info-vin*