### PR TITLE
🎨 Palette: Add missing ARIA labels to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,6 @@
 ## 2024-05-18 - Expanding Generic Component Props for Accessibility
 **Learning:** Reusable UI components like custom Checkboxes and Toggles often encapsulate standard HTML elements but omit crucial accessibility props (like `aria-label`). If a developer uses `<Checkbox />` without a visible `<label>`, screen readers have no context for what the checkbox controls.
 **Action:** Always inspect custom UI primitives to ensure they can accept and forward `aria-label` or `aria-labelledby` props. When creating generic components, include `ariaLabel?: string;` in the props interface and apply it to the underlying interactive element, ideally with a fallback if appropriate.
+## 2025-05-19 - Multiline Scanning for Accessibility Attributes
+**Learning:** Standard line-by-line grep fails to identify missing `aria-label`s on `<button>` elements that span multiple lines, leaving hidden accessibility gaps in JSX code.
+**Action:** When auditing the codebase for missing attributes, use multiline regex scripts (e.g., Python `re.findall(r'<button[^>]*>[\s\S]*?</button>', content)`) to correctly parse and validate components structured across multiple lines.

--- a/enduser-ui-fe/src/features/marketing/components/LeadsCardStack.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/LeadsCardStack.tsx
@@ -340,6 +340,7 @@ export const LeadsCardStack: React.FC<LeadsCardStackProps> = ({ leads, onSwipeRi
                     disabled={history.length === 0}
                     className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center shadow-sm text-gray-500 hover:bg-gray-200 disabled:opacity-30 transition-all"
                     title="Undo Last Swipe"
+                    aria-label="Undo Last Swipe"
                 >
                     <RefreshCwIcon className="w-5 h-5 -scale-x-100" />
                 </button>

--- a/enduser-ui-fe/src/features/marketing/components/VisitLogModal.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/VisitLogModal.tsx
@@ -158,7 +158,7 @@ export const VisitLogModal: React.FC<VisitLogModalProps> = ({ onClose, onSuccess
                                 <div className={`flex-1 p-3 rounded-lg border ${location ? 'bg-green-50 border-green-200 text-green-800' : 'bg-gray-50 border-gray-200 text-gray-500'}`}>
                                     {location ? `${location.lat.toFixed(4)}, ${location.lng.toFixed(4)}` : "No location data"}
                                 </div>
-                                <button onClick={handleLocation} className="p-3 bg-gray-100 rounded-lg hover:bg-gray-200 text-gray-700">
+                                <button onClick={handleLocation} aria-label="Get current location" className="p-3 bg-gray-100 rounded-lg hover:bg-gray-200 text-gray-700">
                                     <MapPinIcon className="w-5 h-5" />
                                 </button>
                             </div>
@@ -199,7 +199,7 @@ export const VisitLogModal: React.FC<VisitLogModalProps> = ({ onClose, onSuccess
                                         <p className="text-sm font-bold text-gray-800 truncate">{audioFile?.name}</p>
                                         <p className="text-xs text-gray-500">Ready to upload</p>
                                     </div>
-                                    <button onClick={clearAudio} className="p-2 hover:bg-red-100 rounded-full text-red-500 transition-colors">
+                                    <button onClick={clearAudio} aria-label="Remove audio recording" className="p-2 hover:bg-red-100 rounded-full text-red-500 transition-colors">
                                         <TrashIcon className="w-4 h-4" />
                                     </button>
                                 </div>

--- a/enduser-ui-fe/src/pages/BrandPage.tsx
+++ b/enduser-ui-fe/src/pages/BrandPage.tsx
@@ -82,7 +82,7 @@ const BrandPage: React.FC = () => {
                     </div>
                     
                     <div className="flex items-center gap-3">
-                        <button onClick={loadData} className="p-2 hover:bg-gray-100 dark:hover:bg-slate-800 rounded-full transition-colors">
+                        <button onClick={loadData} aria-label="Refresh brand data" className="p-2 hover:bg-gray-100 dark:hover:bg-slate-800 rounded-full transition-colors">
                             <RefreshCwIcon className={`w-5 h-5 text-slate-400 ${loading ? 'animate-spin' : ''}`} />
                         </button>
                     </div>


### PR DESCRIPTION
### 💡 What
Added missing `aria-label` attributes to icon-only buttons across multiple components (`BrandPage`, `LeadsCardStack`, `VisitLogModal`).

### 🎯 Why
Icon-only buttons lacking `aria-label`s fail to convey their purpose to screen reader users, resulting in poor accessibility. Adding descriptive labels improves the experience for assistive technology users.

### ♿ Accessibility
- Added `aria-label="Refresh brand data"` to the refresh button in `BrandPage.tsx`.
- Added `aria-label="Undo Last Swipe"` to the undo button in `LeadsCardStack.tsx`.
- Added `aria-label="Get current location"` to the map pin button in `VisitLogModal.tsx`.
- Added `aria-label="Remove audio recording"` to the trash button in `VisitLogModal.tsx`.

---
*PR created automatically by Jules for task [10723876980480671502](https://jules.google.com/task/10723876980480671502) started by @info-vin*