### PR TITLE
🎨 Palette: Add missing ARIA labels to icon-only buttons

### DIFF
--- a/enduser-ui-fe/src/features/marketing/components/BrandDashboardView.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/BrandDashboardView.tsx
@@ -190,6 +190,7 @@ export const BrandDashboardView: React.FC<BrandDashboardViewProps> = ({
                     {logoSvg && (
                         <button
                             onClick={downloadLogo}
+                            aria-label="Download SVG"
                             className="absolute bottom-4 right-4 bg-white/10 backdrop-blur-md text-white p-2 rounded-lg hover:bg-white/20 transition-all opacity-0 group-hover:opacity-100"
                             title="Download SVG"
                         >

--- a/enduser-ui-fe/src/features/marketing/components/workbench/SourceContextPane.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/workbench/SourceContextPane.tsx
@@ -63,6 +63,7 @@ export const SourceContextPane: React.FC<SourceContextPaneProps> = ({
       {/* Floating Sidebar Toggle [2] - Local Context Control */}
       <button
         onClick={onToggleContext}
+        aria-label={isContextOpen ? "Collapse Context" : "Expand Context"}
         className={`absolute bottom-10 z-40 p-2 bg-white dark:bg-slate-800 border dark:border-slate-700 rounded-r-lg shadow-md transition-all duration-500 hover:w-8 group ${
             isContextOpen ? 'left-[33.333333%]' : 'left-0'
         }`}

--- a/enduser-ui-fe/src/pages/DashboardPageA11y.test.tsx
+++ b/enduser-ui-fe/src/pages/DashboardPageA11y.test.tsx
@@ -4,6 +4,21 @@ import { BrowserRouter } from 'react-router-dom';
 import DashboardPage from './DashboardPage';
 import { AuthProvider } from '@/hooks/useAuth';
 
+// Mock the hook to return non-loading state to skip loading screen
+vi.mock('../features/dashboard/hooks/useDashboardLogic', () => ({
+  useDashboardLogic: () => ({
+    projects: [],
+    tasks: [],
+    sortedTasks: [],
+    recentActivity: [],
+    isLoading: false,
+    selectedProjectId: 'all',
+    setSelectedProjectId: vi.fn(),
+    refreshData: vi.fn(),
+    assignableUsers: []
+  })
+}));
+
 // Mock the api to avoid network calls during render
 vi.mock('../services/api', () => ({
   api: {

--- a/enduser-ui-fe/src/pages/SalesCartPage.tsx
+++ b/enduser-ui-fe/src/pages/SalesCartPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { api } from '../services/api';
-import { SparklesIcon, TrashIcon } from '../components/Icons';
+import { SparklesIcon, TrashIcon, XIcon } from '../components/Icons';
 import { PermissionGuard } from '../features/auth/components/PermissionGuard';
 import { EmptyState } from '../components/common/EmptyState';
 
@@ -252,8 +252,8 @@ const PitchModal: React.FC<{ isOpen: boolean; onClose: () => void; content: stri
                         <SparklesIcon className="w-5 h-5 text-indigo-600" />
                         AI Pitch: {company}
                     </h3>
-                    <button onClick={onClose} className="p-1 hover:bg-gray-200 rounded-full text-gray-500 transition-colors">
-                        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
+                    <button onClick={onClose} aria-label="Close modal" className="p-1 hover:bg-gray-200 rounded-full text-gray-500 transition-colors">
+                        <XIcon className="w-6 h-6" />
                     </button>
                 </div>
                 <div className="flex-1 overflow-y-auto p-6 text-gray-700 leading-relaxed space-y-4">


### PR DESCRIPTION
💡 **What:** Added `aria-label`s to icon-only buttons across multiple components (`BrandDashboardView`, `SourceContextPane`, `SalesCartPage`). Also replaced a raw SVG with the standard `XIcon` component.
🎯 **Why:** Icon-only buttons lack accessible names without `aria-label`s, causing screen readers to just announce them as "button". These changes improve accessibility for visually impaired users.
📸 **Before/After:** See attached verification screenshot of the Sales Cart feature.
♿ **Accessibility:**
- Added `aria-label="Download SVG"` to the download button in `BrandDashboardView`.
- Added dynamic `aria-label="Collapse Context" | "Expand Context"` to the pane toggle button in `SourceContextPane`.
- Replaced the inline SVG with `<XIcon>` and added `aria-label="Close modal"` to the close button in `SalesCartPage`.

---
*PR created automatically by Jules for task [2852701217803437870](https://jules.google.com/task/2852701217803437870) started by @info-vin*