### PR TITLE
⚡ Bolt: [performance improvement] Single-pass loop for Ollama health check

### DIFF
--- a/python/src/server/api_routes/ollama/health.py
+++ b/python/src/server/api_routes/ollama/health.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, cast
+from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query
 
@@ -42,15 +42,22 @@ async def health_check_endpoint(
                     "last_checked": None,
                 }
 
-        healthy_count = sum(1 for result in health_results.values() if result["is_healthy"])
+        # PERFORMANCE: Replaced sum(1 for ...) and list comprehension with a single pass loop
+        healthy_count = 0
+        response_times_sum = 0.0
+        response_times_count = 0
+
+        for result in health_results.values():
+            if result["is_healthy"]:
+                healthy_count += 1
+
+            if result.get("response_time_ms") is not None:
+                response_times_sum += result["response_time_ms"]
+                response_times_count += 1
+
         avg_response_time = None
-        if healthy_count > 0:
-            response_times = cast(
-                list[float],
-                [r["response_time_ms"] for r in health_results.values() if r["response_time_ms"] is not None],
-            )
-            if response_times:
-                avg_response_time = sum(response_times) / len(response_times)
+        if healthy_count > 0 and response_times_count > 0:
+            avg_response_time = response_times_sum / response_times_count
 
         return {
             "summary": {


### PR DESCRIPTION
**What:**
Replaced the `sum(1 for result in health_results.values() if result["is_healthy"])` generator and the subsequent list comprehension (`[r["response_time_ms"] ... ]`) in `python/src/server/api_routes/ollama/health.py` with a single-pass `for` loop.

**Why:**
Generators and list comprehensions evaluated separately incur O(N) iteration overhead and memory allocations. Python creates new generator objects and iterates over the dictionary multiple times. A single-pass loop calculates both the healthy count and the sum of response times simultaneously.

**Impact:**
Avoids O(N) generator creation overhead and redundant traversals, reducing memory allocations and improving the performance of the hot path for Ollama instance health checks. 

**Measurement:**
Verified with `ruff` formatting and structural check. Expected lower overhead, especially with a large number of instances checked sequentially.

---
*PR created automatically by Jules for task [4197246729730330959](https://jules.google.com/task/4197246729730330959) started by @info-vin*