### PR TITLE
🎨 Palette: Context-specific ARIA labels on LeadCards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-05-19 - Multiline Scanning for Accessibility Attributes
 **Learning:** Standard line-by-line grep fails to identify missing `aria-label`s on `<button>` elements that span multiple lines, leaving hidden accessibility gaps in JSX code.
 **Action:** When auditing the codebase for missing attributes, use multiline regex scripts (e.g., Python `re.findall(r'<button[^>]*>[\s\S]*?</button>', content)`) to correctly parse and validate components structured across multiple lines.
+
+## 2024-05-03 - Contextual ARIA labels in mapped arrays
+**Learning:** When using generic icon-only buttons (like "Delete", "View", or "Like") inside a list or a grid of identical cards, screen readers will read identically named elements consecutively (e.g. "View Timeline", "View Timeline"). This provides no context as to *which* element the action applies to.
+**Action:** Always use dynamic interpolation when inside of `.map()` lists or components representing a generic child (e.g., `LeadCard.tsx`) so that the `aria-label` includes the uniquely identifying information (like `${lead.company_name}` or `${user.name}`).

--- a/enduser-ui-fe/src/features/marketing/components/LeadCard.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/LeadCard.tsx
@@ -103,28 +103,28 @@ export const LeadCard = ({ lead, style, onDragEnd, onPitch, onHistory }: LeadCar
                 <div className="absolute bottom-20 right-6 flex flex-col gap-3 z-20">
                      <button 
                         onClick={handleHistoryClick}
-                        className="w-12 h-12 bg-white rounded-full shadow-lg border border-gray-100 flex items-center justify-center text-amber-500 hover:bg-amber-50 active:scale-95 transition-all"
+                        className="w-12 h-12 bg-white rounded-full shadow-lg border border-gray-100 flex items-center justify-center text-amber-500 hover:bg-amber-50 active:scale-95 transition-all focus-visible:ring-2 focus-visible:ring-indigo-500"
                         onPointerDown={(e) => e.stopPropagation()}
                         title="View Timeline"
-                        aria-label="View Timeline"
+                        aria-label={`View Timeline for ${lead.company_name}`}
                     >
                         <ActivityIcon className="w-6 h-6" />
                     </button>
                     <button 
                         onClick={handleMap}
-                        className="w-12 h-12 bg-white rounded-full shadow-lg border border-gray-100 flex items-center justify-center text-blue-500 hover:bg-blue-50 active:scale-95 transition-all"
+                        className="w-12 h-12 bg-white rounded-full shadow-lg border border-gray-100 flex items-center justify-center text-blue-500 hover:bg-blue-50 active:scale-95 transition-all focus-visible:ring-2 focus-visible:ring-indigo-500"
                         onPointerDown={(e) => e.stopPropagation()}
                         title="Open Map"
-                        aria-label="Open Map"
+                        aria-label={`Open Map for ${lead.company_name}`}
                     >
                         <MapIcon className="w-6 h-6" />
                     </button>
                     <button 
                         onClick={handlePitchClick}
-                        className={`w-12 h-12 rounded-full shadow-lg flex items-center justify-center text-white active:scale-95 transition-all ${lead.pitch_content ? 'bg-green-600 hover:bg-green-700 shadow-green-200' : 'bg-indigo-600 hover:bg-indigo-700 shadow-indigo-200'}`}
+                        className={`w-12 h-12 rounded-full shadow-lg flex items-center justify-center text-white active:scale-95 transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 ${lead.pitch_content ? 'bg-green-600 hover:bg-green-700 shadow-green-200' : 'bg-indigo-600 hover:bg-indigo-700 shadow-indigo-200'}`}
                         onPointerDown={(e) => e.stopPropagation()}
                         title={lead.pitch_content ? "View Saved Pitch" : "Generate AI Pitch"}
-                        aria-label={lead.pitch_content ? "View Saved Pitch" : "Generate AI Pitch"}
+                        aria-label={lead.pitch_content ? `View Saved Pitch for ${lead.company_name}` : `Generate AI Pitch for ${lead.company_name}`}
                     >
                         <SparklesIcon className="w-6 h-6" />
                     </button>


### PR DESCRIPTION
**💡 What:**
Updated the icon-only Action buttons inside the Marketing `LeadCard` component to include the lead's company name dynamically in their `aria-label` properties. Also added clear keyboard focus styling (`focus-visible:ring-2 focus-visible:ring-indigo-500`).

**🎯 Why:**
When a screen reader user navigates through a list of leads, hearing "View Timeline", "View Timeline", "View Timeline" consecutively provides zero context about *which* lead they are interacting with. By injecting the specific context ("View Timeline for Acme Corp"), the experience becomes far more accessible and understandable.

**📸 Before/After:**
*(Visual change is focus outline, screen reader change is auditory)*
*Before:* `aria-label="View Timeline"` (with generic browser focus ring)
*After:* `aria-label="View Timeline for Acme Corp"` (with indigo focus ring `focus-visible:ring-2 focus-visible:ring-indigo-500`)

**♿ Accessibility:**
- Context-specific ARIA labels implemented using template strings for dynamically generated UI elements within loops.
- Enhanced visual focus indicators to aid keyboard navigation.

---
*PR created automatically by Jules for task [6849345197073592665](https://jules.google.com/task/6849345197073592665) started by @info-vin*