### PR TITLE
⚡ Bolt: Replace list comprehension with for loop in performance stats

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -63,3 +63,6 @@
 ## 2025-05-18 - Replacing len(text.split()) with text.count(' ') is functionally incorrect
 **Learning:** In Python, replacing `len(text.split())` with `text.count(' ') + 1` for word counting or token estimations is functionally incorrect because `split()` handles all whitespace characters (tabs, newlines, multiple spaces) and groups them, whereas `count(' ')` introduces logical bugs by ignoring other whitespaces and miscounting consecutive spaces.
 **Action:** Do not use `text.count(' ') + 1` to replace `len(text.split())`. If performance is a critical issue without allocations, use regex iterators like `sum(1 for _ in re.finditer(r'\S+', text))` or stick to the highly optimized CPython `split()` for general cases.
+## 2024-05-18 - Nested list comprehensions vs explicit loops for counting
+**Learning:** Using `len([1 for x in y for z in x if condition])` causes unnecessary list allocation and generator overhead in Python, slowing down execution.
+**Action:** Replace `len([1 for ...])` with standard `for` loops and a counter variable to prevent allocation overhead.

--- a/python/src/server/services/stats/performance.py
+++ b/python/src/server/services/stats/performance.py
@@ -149,7 +149,13 @@ class PerformanceManager:
 
         avg_weekly_30d = total_30d / 4.28
         momentum = round(((total_7d / avg_weekly_30d) - 1) * 100, 1) if avg_weekly_30d > 0 else 0.0
-        active_paths_count = len([1 for r in formatted_matrix for i in r["interactions"] if i["actual_7d"] > 0])
+
+        # PERFORMANCE: Replaced nested list comprehension with a standard for loop to avoid memory allocation overhead
+        active_paths_count = 0
+        for r in formatted_matrix:
+            for i in r["interactions"]:
+                if i["actual_7d"] > 0:
+                    active_paths_count += 1
 
         # Return dynamic synergy data
         return {


### PR DESCRIPTION
**💡 What:** Replaced the nested list comprehension `len([1 for ...])` with a standard `for` loop and a counter variable in `get_collab_synergy()` within `python/src/server/services/stats/performance.py`.

**🎯 Why:** The previous implementation used a list comprehension to build a new list containing only `1`s just to count the length of the list, which incurs an unnecessary memory allocation and generator overhead in Python.

**📊 Impact:** Eliminates an intermediate list allocation on a highly executed path, reducing memory spikes and mildly improving execution speed for computing active path stats.

**🔬 Measurement:** The logic remains strictly identical. It can be verified by confirming that the exact same integer count is returned and the application behaves identically, but with slightly lower peak memory usage. All syntax checks and automated linters pass cleanly.

---
*PR created automatically by Jules for task [3172486093729344628](https://jules.google.com/task/3172486093729344628) started by @info-vin*