### PR TITLE
⚡ Bolt: Optimize search filter performance in useInspectorPagination

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -69,3 +69,6 @@
 ## 2024-05-18 - String conversions inside array iterators
 **Learning:** In React/JavaScript frontend applications, calling string transformations like `.toLowerCase()` inside iterative array methods (e.g., `.filter()`, `.some()`) causes O(N) redundant string allocations.
 **Action:** Precalculate these values outside the loop to improve rendering performance and memory efficiency.
+## 2026-05-06 - Separating pre-calculation from active filtering in React
+**Learning:** When optimizing React frontend search filters to avoid redundant string allocations (e.g., `.toLowerCase()`), separating the pre-calculation and filtering logic into two distinct `useMemo` hooks is crucial. Combining them executes the allocations on every keystroke, resulting in a de-optimization. The first `useMemo` must cache the pre-calculated search strings (dependent on the source data), and the second `useMemo` should handle the active filtering (dependent on the cached strings and search query).
+**Action:** Always verify the dependency arrays of `useMemo` hooks when pre-calculating string values to ensure they do not re-run on frequent user inputs like search queries.

--- a/archon-ui-main/src/features/knowledge/inspector/hooks/useInspectorPagination.ts
+++ b/archon-ui-main/src/features/knowledge/inspector/hooks/useInspectorPagination.ts
@@ -61,11 +61,12 @@ export function useInspectorPagination({
     initialPageParam: 0,
   });
 
-  // Flatten the paginated data and apply search filtering
-  const { items, totalCount, loadedCount } = useMemo(() => {
+  // PERFORMANCE: Separate data extraction/precalculation from search filtering
+  // This prevents recalculating the search strings on every keystroke
+  const processedData = useMemo(() => {
     type Page = ChunksResponse | CodeExamplesResponse;
     if (!data || !data.pages) {
-      return { items: [], totalCount: 0, loadedCount: 0 };
+      return { allItems: [], searchableItems: [], totalCount: 0, loadedCount: 0 };
     }
 
     // Flatten all pages - data has 'pages' property from useInfiniteQuery
@@ -79,35 +80,37 @@ export function useInspectorPagination({
     const totalCount = first && "total" in first && typeof first.total === "number" ? first.total : allItems.length;
     const loadedCount = allItems.length;
 
-    // Apply search filtering
+    // Precalculate .toLowerCase() searchable string to prevent O(N*M) redundant string allocations during filter
+    const searchableItems = allItems.map((item) => {
+      let searchStr = "";
+      if (viewMode === "documents") {
+        const doc = item as DocumentChunk;
+        searchStr = `${doc.content || ""} ${doc.title || ""} ${doc.metadata?.title || ""} ${doc.metadata?.section || ""}`.toLowerCase();
+      } else {
+        const code = item as CodeExample;
+        searchStr = `${code.content || ""} ${code.summary || ""} ${code.language || ""} ${code.file_path || ""} ${code.title || ""}`.toLowerCase();
+      }
+      return { item, searchStr };
+    });
+
+    return { allItems, searchableItems, totalCount, loadedCount };
+  }, [data, viewMode]);
+
+  // Apply search filtering
+  const { items, totalCount, loadedCount } = useMemo(() => {
+    const { allItems, searchableItems, totalCount, loadedCount } = processedData;
+
     if (!searchQuery) {
       return { items: allItems, totalCount, loadedCount };
     }
 
     const query = searchQuery.toLowerCase();
-    const filteredItems = allItems.filter((item: DocumentChunk | CodeExample) => {
-      if (viewMode === "documents") {
-        const doc = item as DocumentChunk;
-        return (
-          doc.content?.toLowerCase().includes(query) ||
-          doc.title?.toLowerCase().includes(query) ||
-          doc.metadata?.title?.toLowerCase().includes(query) ||
-          doc.metadata?.section?.toLowerCase().includes(query)
-        );
-      } else {
-        const code = item as CodeExample;
-        return (
-          code.content?.toLowerCase().includes(query) ||
-          code.summary?.toLowerCase().includes(query) ||
-          code.language?.toLowerCase().includes(query) ||
-          code.file_path?.toLowerCase().includes(query) ||
-          code.title?.toLowerCase().includes(query)
-        );
-      }
-    });
+    const filteredItems = searchableItems
+      .filter(({ searchStr }) => searchStr.includes(query))
+      .map(({ item }) => item);
 
     return { items: filteredItems, totalCount, loadedCount };
-  }, [data, viewMode, searchQuery]);
+  }, [processedData, searchQuery]);
 
   return {
     items,


### PR DESCRIPTION
## 💡 What
Separated the `useMemo` block in `useInspectorPagination.ts` into two separate `useMemo` hooks.
1. The first `useMemo` (`processedData`) precalculates the flattened array and the `.toLowerCase()` searchable string for each item. It only depends on `[data, viewMode]`.
2. The second `useMemo` actively filters the precalculated data based on the `searchQuery`.

## 🎯 Why
Previously, the search filter iteratively mapped over the paginated data and called `.toLowerCase()` on multiple string fields for every document during every keystroke update of `searchQuery`. While attempting to precalculate this into a single searchable string earlier, it was mistakenly placed inside the same `useMemo` that depended on `searchQuery`, which resulted in the mapped array re-allocating and re-evaluating on every keystroke anyway. This caused redundant `O(N*M)` string allocations and excessive Garbage Collection overhead.

## 📊 Impact
*   **Significantly reduces CPU overhead and memory allocations:** By moving the pre-calculation of `.toLowerCase()` strings into a separate `useMemo`, we avoid creating new strings for thousands of list items on every keystroke.
*   **Improves UI responsiveness:** Filtering is now a simple `searchStr.includes(query)` check, which reduces the time the main thread is blocked during typing in the search bar.

## 🔬 Measurement
1.  Run `pnpm test` in the `archon-ui-main` directory.
2.  All existing pagination, display, and integration tests should pass successfully.
3.  Open the Inspector and perform text searches; you will observe a snappier response, especially with larger sets of document chunks.

---
*PR created automatically by Jules for task [8712984364708885758](https://jules.google.com/task/8712984364708885758) started by @info-vin*