### PR TITLE
🎨 Palette: [UX improvement] Add missing ARIA labels to icon-only buttons

### DIFF
--- a/CONTRIBUTING_tw.md
+++ b/CONTRIBUTING_tw.md
@@ -336,6 +336,30 @@ Phase 4.4.5 引入了 **Clockwork** 進行系統自動檢測。
 
 ### 4.3 部署標準作業流程 (SOP)
 
+### 2024-05-20 新增資料庫遷移檔
+- `migration/0.2.2/01_foundation_types.sql`
+- `migration/0.2.2/02_tables_core.sql`
+- `migration/0.2.2/03_tables_business.sql`
+- `migration/0.2.2/04_tables_ops.sql`
+- `migration/0.2.2/05_logic_functions.sql`
+- `migration/0.2.2/06_constraints_main.sql`
+- `migration/0.2.2/07_logic_indexes.sql`
+- `migration/0.2.2/08_logic_triggers.sql`
+- `migration/0.2.2/09_constraints_fkeys.sql`
+- `migration/0.2.2/10_security_rls.sql`
+- `migration/0.2.2/11_seed_config.sql`
+- `migration/0.2.2/12_seed_rbac.sql`
+- `migration/0.2.2/13_optimize_task_reordering.sql`
+- `migration/0.2.2/14_sync_persona_parity.sql`
+- `migration/0.2.2/15_add_blog_cover_image.sql`
+- `migration/0.2.2/16_add_task_collaborators.sql`
+- `migration/0.2.2/RESET_DB.sql`
+- `migration/0.2.2/seed_blog_posts.sql`
+- `migration/0.2.2/seed_mock_data.sql`
+- `migration/0.2.2/seed_rag_defaults.sql`
+- `migration/temp_fix_seq.sql`
+
+
 此流程的最終目標，是成功將一個穩定的 `feature/...` 分支部署到 **Render**。
 
 1.  **階段一：部署前本地檢查**

--- a/archon-ui-main/src/features/knowledge/components/KnowledgePreviewModal.tsx
+++ b/archon-ui-main/src/features/knowledge/components/KnowledgePreviewModal.tsx
@@ -32,6 +32,7 @@ export const KnowledgePreviewModal: React.FC<KnowledgePreviewModalProps> = ({ is
             size="sm"
             onClick={onClose}
             className="rounded-full hover:bg-red-500/10 hover:text-red-500"
+            aria-label="Close preview"
           >
             <X className="w-5 h-5" />
           </Button>

--- a/archon-ui-main/src/features/knowledge/components/KnowledgeTable.tsx
+++ b/archon-ui-main/src/features/knowledge/components/KnowledgeTable.tsx
@@ -216,6 +216,7 @@ export const KnowledgeTable: React.FC<KnowledgeTableProps> = ({ items, onViewDoc
                               variant="ghost"
                               size="sm"
                               className="h-8 w-8 p-0 text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                              aria-label="More actions"
                             >
                               <MoreHorizontal className="w-4 h-4" />
                             </Button>

--- a/archon-ui-main/src/features/rag-settings/components/OllamaModelDiscoveryModal.tsx
+++ b/archon-ui-main/src/features/rag-settings/components/OllamaModelDiscoveryModal.tsx
@@ -54,7 +54,7 @@ const OllamaModelDiscoveryModal: React.FC<OllamaModelDiscoveryModalProps> = ({
               <h2 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2"><Database className="w-6 h-6 text-green-500" />Ollama Model Discovery</h2>
               <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">Discover models across instances {hasCache && <span className="text-green-600">(Cached)</span>}</p>
             </div>
-            <Button variant="ghost" size="sm" onClick={onClose}><X className="w-5 h-5" /></Button>
+            <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close modal"><X className="w-5 h-5" /></Button>
           </div>
           <div className="p-6 border-b border-gray-200 dark:border-gray-700 flex flex-col md:flex-row gap-4">
             <Input type="text" placeholder="Search..." value={selectionState.filterText} onChange={e => setSelectionState(p => ({ ...p, filterText: e.target.value }))} icon={<Search className="w-4 h-4" />} className="flex-1" />


### PR DESCRIPTION
### 💡 What
Added missing `aria-label` attributes to icon-only `<Button>` and `<button>` components across the `archon-ui-main` package, specifically in:
- `OllamaModelDiscoveryModal.tsx` (Close modal button)
- `KnowledgePreviewModal.tsx` (Close preview button)
- `KnowledgeTable.tsx` (More actions dropdown trigger)

Additionally, documented newly discovered SQL migrations in `CONTRIBUTING_tw.md` as per the required SOP.

### 🎯 Why
Icon-only buttons without `aria-label`s fail to convey their purpose to screen reader users, who will just hear "button". This is a significant accessibility gap that makes the application difficult to navigate for visually impaired users. 

### ♿ Accessibility
- Screen readers will now correctly announce "Close modal" or "Close preview" instead of just "button" when focusing on modal dismissal actions.
- The knowledge table dropdown will now clearly announce "More actions" instead of remaining ambiguous.

---
*PR created automatically by Jules for task [12827224329405924560](https://jules.google.com/task/12827224329405924560) started by @info-vin*