### PR TITLE
🎨 Palette: Add ARIA label to Smart Image Picker close button

### DIFF
--- a/enduser-ui-fe/src/features/marketing/components/SmartImagePicker.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/SmartImagePicker.tsx
@@ -37,7 +37,7 @@ export const SmartImagePicker: React.FC<SmartImagePickerProps> = ({ onSelect, on
             <ImageIcon className="w-5 h-5 text-indigo-600" />
             Smart Image Picker
           </h2>
-          <button onClick={onClose} className="p-2 hover:bg-gray-100 rounded-full text-gray-500 transition-colors">
+          <button onClick={onClose} className="p-2 hover:bg-gray-100 rounded-full text-gray-500 transition-colors" aria-label="Close Smart Image Picker">
             <XIcon className="w-5 h-5" />
           </button>
         </div>


### PR DESCRIPTION
💡 What: Added an `aria-label` attribute to the icon-only close button in `SmartImagePicker.tsx`.
🎯 Why: To ensure that screen reader users can understand the purpose of the close button.
📸 Before/After: The visual appearance remains unchanged, but the button is now accessible to screen readers.
♿ Accessibility: Improved accessibility by providing a descriptive label for an interactive element that lacked text content.

---
*PR created automatically by Jules for task [7793653028488228655](https://jules.google.com/task/7793653028488228655) started by @info-vin*