### PR TITLE
🎨 Palette: Add loading state to SentinelRadar rules save

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-19 - Adding loading state to APPROVE button requires test mock updates
 **Learning:** When adding a loading state that introduces a new icon component (like `RefreshCwIcon`) to an existing component (like `EthicsAuditPanel`), the unit tests will fail if that new icon is not also added to the `vi.mock` section of the corresponding `.test.tsx` file.
 **Action:** Always check the `.test.tsx` file of the component being modified. If it uses `vi.mock` for its children components or icons, ensure any newly added dependencies in the implementation are mirrored in the mock setup before running tests.
+## 2026-05-11 - Add loading state to async configuration save button
+**Learning:** System configurations and settings changes (like saving SentinelRadar scoring rules) often lack loading states because they're plain text buttons or text links instead of primary action buttons. Adding visual loading states (e.g., "Saving..." with a spinner) provides necessary feedback and prevents confusion during API delays.
+**Action:** Always check text-based actions and configuration save buttons for asynchronous loading states, disabling the element and displaying a spinner while processing.

--- a/enduser-ui-fe/src/features/manager/components/SentinelRadar.tsx
+++ b/enduser-ui-fe/src/features/manager/components/SentinelRadar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ZapIcon, CheckCircleIcon } from '../../../components/Icons';
+import { ZapIcon, CheckCircleIcon, RefreshCwIcon } from '../../../components/Icons';
 
 interface SentinelRadarProps {
     businessRisks: any[];
@@ -7,13 +7,14 @@ interface SentinelRadarProps {
     handleDispatch: (alertId: string) => Promise<void>;
     rules: any[];
     rulesMeta: { version: string };
+    isSavingRules?: boolean;
     handleRuleChange: (key: string, weight: number) => void;
     handleSaveRules: () => Promise<void>;
 }
 
 export const SentinelRadar: React.FC<SentinelRadarProps> = ({
     businessRisks, processingId, handleDispatch,
-    rules, rulesMeta, handleRuleChange, handleSaveRules
+    rules, rulesMeta, isSavingRules, handleRuleChange, handleSaveRules
 }) => {
     return (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -82,7 +83,18 @@ export const SentinelRadar: React.FC<SentinelRadarProps> = ({
                     <span className={`text-xs font-bold ${rules.reduce((a,b)=>a+b.weight,0) === 100 ? 'text-green-500' : 'text-red-500'}`}>
                         Total: {rules.reduce((a,b)=>a+b.weight,0)}%
                     </span>
-                    <button onClick={handleSaveRules} className="text-xs font-bold text-indigo-600 hover:underline">Save Changes</button>
+                    <button
+                        onClick={handleSaveRules}
+                        disabled={isSavingRules}
+                        className="text-xs font-bold text-indigo-600 hover:underline disabled:opacity-50 flex items-center gap-1"
+                    >
+                        {isSavingRules ? (
+                            <>
+                                <RefreshCwIcon className="w-3 h-3 animate-spin" />
+                                Saving...
+                            </>
+                        ) : 'Save Changes'}
+                    </button>
                 </div>
             </div>
         </div>

--- a/enduser-ui-fe/src/features/manager/hooks/useManagerNexusStats.ts
+++ b/enduser-ui-fe/src/features/manager/hooks/useManagerNexusStats.ts
@@ -52,6 +52,7 @@ export const useManagerNexusStats = () => {
         updated_at: new Date().toISOString(),
         updated_by: 'System Default'
     });
+    const [isSavingRules, setIsSavingRules] = useState(false);
 
     const fetchData = useCallback(async () => {
         setLoading(true);
@@ -209,6 +210,7 @@ export const useManagerNexusStats = () => {
             ...newMeta
         };
 
+        setIsSavingRules(true);
         try {
             await api.updateSystemSetting('marketing_scoring', { 
                 value: JSON.stringify(payload),
@@ -218,6 +220,8 @@ export const useManagerNexusStats = () => {
             alert("Scoring Rules Saved to Database!");
         } catch (e: any) {
             alert("Failed to save rules: " + e.message);
+        } finally {
+            setIsSavingRules(false);
         }
     };
 
@@ -227,7 +231,7 @@ export const useManagerNexusStats = () => {
         overview, healthTrend, team, approvals, alerts, aiStats,
         commanderTrends, forceReadiness, businessRisks, collabSynergy,
         slaReliability, ethicsAudit, knowledgeRoi, codeProposals,
-        rules, setRules, rulesMeta, setRulesMeta,
+        rules, setRules, rulesMeta, setRulesMeta, isSavingRules,
         fetchData, handleDispatch, handleApprovePrompt, handleRebuildIndex,
         handleApproveContent, handleCodeAction, handleRuleChange, handleSaveRules
     };

--- a/enduser-ui-fe/src/pages/ManagerNexus.tsx
+++ b/enduser-ui-fe/src/pages/ManagerNexus.tsx
@@ -48,7 +48,7 @@ export const ManagerNexus: React.FC = () => {
         overview, healthTrend, team, approvals, alerts, aiStats,
         commanderTrends, forceReadiness, businessRisks, collabSynergy,
         slaReliability, ethicsAudit, knowledgeRoi, codeProposals,
-        rules, rulesMeta,
+        rules, rulesMeta, isSavingRules,
         fetchData, handleDispatch, handleApprovePrompt, handleRebuildIndex,
         handleApproveContent, handleCodeAction, handleRuleChange, handleSaveRules
     } = useManagerNexusStats();
@@ -115,6 +115,7 @@ export const ManagerNexus: React.FC = () => {
                             handleDispatch={handleDispatch}
                             rules={rules}
                             rulesMeta={rulesMeta}
+                            isSavingRules={isSavingRules}
                             handleRuleChange={handleRuleChange}
                             handleSaveRules={handleSaveRules}
                         />


### PR DESCRIPTION
💡 What: Added an `isSavingRules` loading state to the `SentinelRadar` component's "Save Changes" action.
🎯 Why: Configuration changes require a network request, but previously the UI provided no feedback while saving, which could lead to confusion or duplicate clicks.
📸 Before/After: Before, the button remained static. After, the button disables and displays a spinning icon with "Saving..." text while the API request processes.
♿ Accessibility: Disabling the button during processing prevents unintended double-submissions.

---
*PR created automatically by Jules for task [7718642881220918653](https://jules.google.com/task/7718642881220918653) started by @info-vin*