### PR TITLE
🎨 Palette: Add ARIA label to delete post button

### DIFF
--- a/enduser-ui-fe/src/features/admin/components/AdminContentManager.tsx
+++ b/enduser-ui-fe/src/features/admin/components/AdminContentManager.tsx
@@ -37,7 +37,14 @@ export const AdminContentManager: React.FC = () => {
                                 <td className="px-6 py-4 capitalize">{post.status}</td>
                                 <td className="px-6 py-4">{new Date(post.publishDate).toLocaleDateString()}</td>
                                 <td className="px-6 py-4 text-right">
-                                    <button onClick={() => deletePost(post.id)} className="text-red-500 hover:text-red-700"><TrashIcon className="w-4 h-4"/></button>
+                                    <button
+                                        onClick={() => deletePost(post.id)}
+                                        className="p-1.5 text-red-500 hover:bg-red-50 rounded-md transition-colors focus-visible:ring-2 focus-visible:ring-red-500 outline-none"
+                                        aria-label="Delete post"
+                                        title="Delete post"
+                                    >
+                                        <TrashIcon className="w-4 h-4" />
+                                    </button>
                                 </td>
                             </tr>
                         )) : (


### PR DESCRIPTION
💡 What: Added aria-label, title, and focus visible styles to icon-only delete button in Admin Content Manager.
🎯 Why: Fixes accessibility issue for screen readers traversing table actions and improves keyboard navigation/visual feedback.
📸 Before/After: Before it lacked aria-label and outline ring, after it has full accessibility features.
♿ Accessibility: Added aria-label, title, focus-visible:ring-2, and hover background.

---
*PR created automatically by Jules for task [3762357700988673911](https://jules.google.com/task/3762357700988673911) started by @info-vin*