### PR TITLE
🤖 QA: Fix URL parsing network error in E2E tests

### DIFF
--- a/enduser-ui-fe/tests/e2e/pre-setup.ts
+++ b/enduser-ui-fe/tests/e2e/pre-setup.ts
@@ -5,6 +5,9 @@ import { vi } from 'vitest';
  * Using Object.defineProperty to lock down globals before React ever runs.
  */
 
+// Inject default test API URL so URL parsing doesn't fail
+vi.stubEnv('VITE_API_URL', 'http://localhost');
+
 const mockMatchMedia = vi.fn().mockImplementation(query => ({
   matches: false,
   media: query,


### PR DESCRIPTION
🤖 QA: Daily E2E Fixes - Fix URL parsing network error in E2E tests

* 📊 Status: E2E tests experiencing network parsing errors due to undefined base URL
* 🚨 Failures: `Failed to fetch attendance status APIServiceError: Failed to call API /api/visit-logs/attendance/status: Failed to parse URL from /api/visit-logs/attendance/status`
* 🛠️ Fixes Applied: Injected a default `VITE_API_URL` environment variable using `vi.stubEnv` in `enduser-ui-fe/tests/e2e/pre-setup.ts` to prevent URL parsing failures.
* ⚠️ Blockers: Several tests remain failing due to unresolved timeouts.
* 💡 Recommendations: Investigate test timeout limits or improve loading state waiting mechanisms for asynchronous rendering tests.

---
*PR created automatically by Jules for task [15887098207528479451](https://jules.google.com/task/15887098207528479451) started by @info-vin*