### PR TITLE
🎨 Palette: Add aria-label to corner radius toggle button

### DIFF
--- a/archon-ui-main/src/components/settings/playground/PlaygroundControls.tsx
+++ b/archon-ui-main/src/components/settings/playground/PlaygroundControls.tsx
@@ -82,6 +82,7 @@ export const PlaygroundControls: React.FC<PlaygroundControlsProps> = (props) => 
     <div className="flex items-center gap-1">
       <button
         onClick={() => toggleLink(layer, corner)}
+        aria-label={linked ? 'Unlink corner radius' : 'Link corner radius'}
         className={cn(
           'w-5 h-5 rounded border transition-all flex items-center justify-center',
           linked ? 'bg-blue-500 border-blue-600 text-white' : 'bg-gray-200 dark:bg-gray-700 border-gray-300 dark:border-gray-600'


### PR DESCRIPTION
### 💡 What
Added an `aria-label` attribute to the icon-only toggle button inside the `CornerInput` subcomponent of `PlaygroundControls`. The label dynamically displays 'Unlink corner radius' or 'Link corner radius' depending on the current `linked` state.

### 🎯 Why
Icon-only buttons must have accessible names for screen readers. Without an `aria-label`, users relying on assistive technologies would only hear "button" without knowing its function, leading to a confusing user experience.

### 📸 Before/After
*   **Before:** `<button onClick={() => toggleLink(layer, corner)} className="..."> {linked ? <Link /> : <Unlink />} </button>`
*   **After:** `<button onClick={() => toggleLink(layer, corner)} aria-label={linked ? 'Unlink corner radius' : 'Link corner radius'} className="..."> {linked ? <Link /> : <Unlink />} </button>`

### ♿ Accessibility
This change ensures compliance with WCAG standards for interactive elements by providing a descriptive, context-aware programmatic name to an otherwise purely visual icon button.

---
*PR created automatically by Jules for task [5912930910969342474](https://jules.google.com/task/5912930910969342474) started by @info-vin*