### PR TITLE
🎨 Palette: Add ARIA roles to TaskModal tabs

### DIFF
--- a/enduser-ui-fe/src/components/TaskModal.tsx
+++ b/enduser-ui-fe/src/components/TaskModal.tsx
@@ -253,11 +253,13 @@ export const TaskModal: React.FC<TaskModalProps> = ({ task, onClose, onTaskCreat
         </div>
 
         {/* Tabs Header */}
-        <div className="flex w-full border-b border-border mb-4 flex-shrink-0 overflow-x-auto custom-scrollbar pb-0">
+        <div className="flex w-full border-b border-border mb-4 flex-shrink-0 overflow-x-auto custom-scrollbar pb-0" role="tablist" aria-label="Task Details Tabs">
           {tabs.map(tab => (
             <button
               key={tab.id}
               type="button"
+              role="tab"
+              aria-selected={activeTab === tab.id}
               onClick={() => setActiveTab(tab.id as TabType)}
               className={`flex-1 px-2 py-3 text-xs sm:text-sm font-medium border-b-2 transition-colors text-center whitespace-nowrap ${activeTab === tab.id ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'}`}
             >


### PR DESCRIPTION
### 💡 What
Added `role="tablist"`, `role="tab"`, and `aria-selected` attributes to the custom tab navigation in `enduser-ui-fe/src/components/TaskModal.tsx`. Also added an `aria-label` to the tab container.

### 🎯 Why
To improve accessibility for screen reader users by properly defining the tab structure and state. Previously, the tabs were just a group of buttons without semantic grouping or active state indicators recognizable by assistive technologies.

### 📸 Before/After
*(No visual changes, only semantic HTML attributes were modified)*

### ♿ Accessibility
- Screen readers will now announce the container as a tablist.
- Each button will be announced as a tab.
- The active tab will be announced as selected (`aria-selected="true"`).

---
*PR created automatically by Jules for task [253557385810524106](https://jules.google.com/task/253557385810524106) started by @info-vin*