### PR TITLE
🎨 Palette: Add ARIA attributes to AudioPlayer button

### DIFF
--- a/enduser-ui-fe/src/components/common/AudioPlayer.tsx
+++ b/enduser-ui-fe/src/components/common/AudioPlayer.tsx
@@ -148,6 +148,8 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
             <button
                 onClick={handlePlayPause}
                 disabled={isLoading}
+                aria-label={isLoading ? "Loading audio" : isPlaying ? "Pause audio" : label}
+                aria-pressed={isPlaying}
                 className="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-50 active:bg-gray-100 transition-colors disabled:opacity-50"
             >
                 {isLoading ? (


### PR DESCRIPTION
💡 What
Added `aria-label` and `aria-pressed` attributes to the play/pause button in `AudioPlayer.tsx`. The `aria-label` dynamically updates based on the `isLoading` and `isPlaying` state.

🎯 Why
The play/pause button in `AudioPlayer.tsx` sometimes acts as an icon-only button (when `isExpanded` is true, the label span is not rendered). Adding a dynamic `aria-label` and `aria-pressed` toggle state ensures that screen readers can correctly identify the action (e.g., "Pause audio", "Play audio", "Loading audio") and the current state of the button.

📸 Before/After
Before:
```tsx
<button
    onClick={handlePlayPause}
    disabled={isLoading}
    className="..."
>
```
After:
```tsx
<button
    onClick={handlePlayPause}
    disabled={isLoading}
    aria-label={isLoading ? "Loading audio" : isPlaying ? "Pause audio" : label}
    aria-pressed={isPlaying}
    className="..."
>
```

♿ Accessibility
Improves screen reader support for the audio controls. Screen readers will now announce "Pause audio, toggle button, pressed" or "Play audio, toggle button, not pressed", providing critical context that was previously missing.

---
*PR created automatically by Jules for task [850247511627001461](https://jules.google.com/task/850247511627001461) started by @info-vin*