### PR TITLE
⚡ Bolt: Memoize permission checks to prevent render overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -97,3 +97,6 @@
 ## 2024-10-24 - React Component Static Weights Dictionary Allocation
 **Learning:** Defining static objects like lookup dictionaries (`STATUS_WEIGHTS`, `PRIORITY_WEIGHTS`) inside a React component or hook function causes them to be recreated on every single render cycle, wasting memory and CPU.
 **Action:** Move static objects or constant lookup dictionaries outside the component or hook definition to prevent them from being reallocated on every render. Additionally, when using these dictionaries inside array sort comparators, retain `.toLowerCase()` for true case-insensitivity rather than expanding the dictionary with specific casing variations, as the latter is a flawed micro-optimization.
+## 2024-05-24 - Expensive Hook Invocations
+**Learning:** Found a severe anti-pattern where a hook returned a function (`hasPermission`) that executed O(N) array transformations, string allocations, and Set creations *on every invocation* during render, rather than pre-calculating the state based on dependencies.
+**Action:** Always memoize derived state (like Set creation from arrays) outside of returned callback functions within hooks, ensuring expensive operations only run when underlying dependencies change.

--- a/enduser-ui-fe/src/features/auth/hooks/usePermission.ts
+++ b/enduser-ui-fe/src/features/auth/hooks/usePermission.ts
@@ -1,5 +1,6 @@
 // enduser-ui-fe/src/features/auth/hooks/usePermission.ts
 
+import { useMemo, useCallback } from 'react';
 import { EmployeeRole, PermissionScope } from '../types';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -47,29 +48,28 @@ const ROLE_MAP: Record<string, Set<string>> = {
 export function usePermission() {
   const { user } = useAuth();
   
-  const hasPermission = (permission: PermissionScope): boolean => {
-    if (!user) {
-        return false;
-    }
+  // PERFORMANCE: Precalculate and memoize the full permission set based on the current user.
+  // This prevents O(N) array mapping, redundant string allocations (.toLowerCase()),
+  // and Set instantiations on every single call to hasPermission during render.
+  const allPerms = useMemo(() => {
+    if (!user) return new Set<string>();
 
-    const normalizedReq = permission.toLowerCase();
-
-    // Combined Source: Dynamic + Static Fallback (SSOT)
     const dynamicPerms = user.permissions || (user as any).scopes || [];
-    
-    // Get Static Set based on role
     const normalizedRole = (user.role || '').toLowerCase();
     const staticPermsSet = ROLE_MAP[normalizedRole] || new Set();
     
-    // Union of both sources for 100% reliability
-    const allPerms = new Set([
+    return new Set([
         ...dynamicPerms.map((p: string) => p.toLowerCase()),
         ...Array.from(staticPermsSet).map((p: any) => p.toLowerCase())
     ]);
+  }, [user]);
 
+  const hasPermission = useCallback((permission: PermissionScope): boolean => {
+    if (!user) return false;
     if (allPerms.has('*')) return true;
-    return allPerms.has(normalizedReq);
-  };
+
+    return allPerms.has(permission.toLowerCase());
+  }, [user, allPerms]);
 
   return { hasPermission };
 }


### PR DESCRIPTION
💡 What:
Memoized the calculation of the `allPerms` Set inside the `usePermission` hook so it only recalculates when the `user` object changes, and wrapped `hasPermission` in `useCallback`.

🎯 Why:
The `hasPermission` function is called frequently during rendering to conditionally display UI elements based on user permissions. Previously, this function was iterating through arrays, allocating lowercase strings, and instantiating a new `Set` on *every single invocation*. This caused unnecessary O(N) allocations and operations during the render cycle, blocking the main thread.

📊 Impact:
Reduces O(N) array mapping and Set creation per-call down to a single O(1) Set lookup. Prevents redundant string allocations and memory garbage collection overhead during UI renders.

🔬 Measurement:
Run `pnpm run test:unit && pnpm test:e2e` to verify permission logic is perfectly preserved. Use React DevTools Profiler to verify `hasPermission` execution time is drastically reduced during navigation.

---
*PR created automatically by Jules for task [7379157021537335996](https://jules.google.com/task/7379157021537335996) started by @info-vin*