### PR TITLE
🎨 Palette: [UX improvement] Add ARIA accessibility to Role Matrix toggle buttons

### DIFF
--- a/enduser-ui-fe/src/features/admin/components/IdentityMatrix.tsx
+++ b/enduser-ui-fe/src/features/admin/components/IdentityMatrix.tsx
@@ -172,6 +172,8 @@ export const IdentityMatrix: React.FC = () => {
                                                     <button 
                                                         onClick={() => toggleMatrixPermission(row.role, perm)}
                                                         className={`w-6 h-6 rounded-md border flex items-center justify-center mx-auto transition-all ${hasPerm ? 'bg-green-500 border-green-600 text-white' : 'bg-background border-border text-transparent hover:border-primary/50'}`}
+                                                        aria-label={`Toggle permission ${perm} for role ${row.role}`}
+                                                        aria-pressed={hasPerm}
                                                     >
                                                         {hasPerm && <CheckCircleIcon className="w-4 h-4" />}
                                                     </button>


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add ARIA accessibility to Role Matrix toggle buttons

💡 What: Added `aria-label` and `aria-pressed` attributes to the permission toggle buttons in the Identity Matrix.
🎯 Why: The buttons were icon-only and lacked context for screen readers, making it difficult for visually impaired users to manage role permissions effectively.
📸 Before/After: Visuals remain unchanged, but screen readers now accurately announce the toggle state and target permission.
♿ Accessibility: Screen reader compatibility for matrix toggle inputs.

---
*PR created automatically by Jules for task [11473924185219275790](https://jules.google.com/task/11473924185219275790) started by @info-vin*