### PR TITLE
🎨 Palette: Add loading state to async Archive button

### DIFF
--- a/enduser-ui-fe/src/components/TaskModal.test.tsx
+++ b/enduser-ui-fe/src/components/TaskModal.test.tsx
@@ -4,6 +4,16 @@ import { TaskModal } from './TaskModal';
 import userEvent from '@testing-library/user-event';
 import { Task, TaskPriority, TaskStatus } from '../types';
 
+// Mock Icons
+vi.mock('./Icons.tsx', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./Icons.tsx')>();
+  return {
+    ...actual,
+    XIcon: () => <span>XIcon</span>,
+    RefreshCwIcon: () => <span>RefreshCwIcon</span>,
+  };
+});
+
 // Mock API
 vi.mock('../services/api', () => ({
   api: {

--- a/enduser-ui-fe/src/components/TaskModal.tsx
+++ b/enduser-ui-fe/src/components/TaskModal.tsx
@@ -323,9 +323,11 @@ export const TaskModal: React.FC<TaskModalProps> = ({ task, onClose, onTaskCreat
                   type="button" 
                   onClick={handleDelete} 
                   disabled={isSubmitting}
-                  className="px-4 py-2 rounded-md bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 text-sm"
+                  aria-label={isSubmitting ? 'Archiving task...' : 'Archive Task'}
+                  className="px-4 py-2 rounded-md bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 text-sm flex items-center justify-center gap-2"
                 >
-                  Archive Task
+                  {isSubmitting && <RefreshCwIcon className="w-4 h-4 animate-spin" />}
+                  {isSubmitting ? 'Archiving...' : 'Archive Task'}
                 </button>
               )}
             </div>


### PR DESCRIPTION
🎨 Palette: Add loading state to async Archive button

💡 What: Added a visual loading spinner (`RefreshCwIcon`) and "Archiving..." status text to the destructive "Archive Task" button in `TaskModal`. Updated `TaskModal.test.tsx` to partially mock the `Icons.tsx` module to include the new icon.
🎯 Why: Destructive or important async actions often lack visual loading states compared to primary actions. This provides immediate feedback and prevents duplicate clicks or confusion during network latency, adhering to the critical UX learning documented for this app.
📸 Before/After: The button transitions from a static "Archive Task" to a disabled button with a spinner and "Archiving..." text when clicked.
♿ Accessibility: Added dynamic `aria-label` to announce "Archiving task..." to screen readers while processing.

---
*PR created automatically by Jules for task [1828702588860866700](https://jules.google.com/task/1828702588860866700) started by @info-vin*