### PR TITLE
🎨 Palette: Add ARIA label and title to Admin Analytics refresh button

### DIFF
--- a/enduser-ui-fe/src/features/admin/components/AdminCorrectionAnalytics.tsx
+++ b/enduser-ui-fe/src/features/admin/components/AdminCorrectionAnalytics.tsx
@@ -49,6 +49,8 @@ export const AdminCorrectionAnalytics: React.FC = () => {
             onClick={() => send({ type: 'FETCH' })}
             disabled={isLoading}
             className="p-2 text-gray-500 hover:bg-gray-100 rounded-lg transition-colors disabled:opacity-50"
+            aria-label="Refresh analytics"
+            title="Refresh analytics"
           >
             <RefreshCwIcon className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
           </button>


### PR DESCRIPTION
💡 What: Added an `aria-label` and `title` to the icon-only refresh button in the `AdminCorrectionAnalytics` component.
🎯 Why: Improves screen reader accessibility and provides a helpful tooltip for mouse users, clarifying the button's purpose since it only contained an icon.
📸 Before/After: Added `aria-label="Refresh analytics"` and `title="Refresh analytics"`.
♿ Accessibility: Screen readers will now announce "Refresh analytics" instead of ignoring the button or reading generic text.

---
*PR created automatically by Jules for task [15681128030188699563](https://jules.google.com/task/15681128030188699563) started by @info-vin*