### PR TITLE
🎨 Palette: Add title attribute to close button

### DIFF
--- a/enduser-ui-fe/src/features/manager/components/ContentReviewPanel.tsx
+++ b/enduser-ui-fe/src/features/manager/components/ContentReviewPanel.tsx
@@ -84,7 +84,7 @@ export const ContentReviewPanel: React.FC<ContentReviewPanelProps> = ({
                                     <span className="text-[10px] text-gray-400 font-bold uppercase">{selectedContent.author_name || selectedContent.authorName}</span>
                                 </div>
                             </div>
-                            <button onClick={() => setSelectedContent(null)} className="p-2 hover:bg-gray-200 rounded-full transition-colors" aria-label="Close content preview"><XIcon className="w-4 h-4" /></button>
+                            <button onClick={() => setSelectedContent(null)} className="p-2 hover:bg-gray-200 rounded-full transition-colors" aria-label="Close content preview" title="Close content preview"><XIcon className="w-4 h-4" /></button>
                         </div>
 
                         <div className="prose prose-sm dark:prose-invert max-w-none mb-8 bg-white dark:bg-slate-950 p-6 rounded-xl border border-gray-100 dark:border-slate-800 shadow-sm overflow-hidden">


### PR DESCRIPTION
💡 What: Added a `title` attribute to the icon-only close button in `ContentReviewPanel.tsx`.
🎯 Why: To provide a native hover tooltip for visual users, improving usability.
📸 Before/After: Before, visual users had no context on hover; after, they see a "Close content preview" tooltip.
♿ Accessibility: Maintains the existing `aria-label` for screen readers while enhancing usability for visual users.

---
*PR created automatically by Jules for task [869196621533314822](https://jules.google.com/task/869196621533314822) started by @info-vin*