### PR TITLE
🎨 Palette: Add native tooltip to ActiveForce view details button

### DIFF
--- a/enduser-ui-fe/src/features/manager/components/ActiveForce.tsx
+++ b/enduser-ui-fe/src/features/manager/components/ActiveForce.tsx
@@ -110,6 +110,7 @@ export const ActiveForce: React.FC<ActiveForceProps> = ({
                             onClick={() => setSelectedMember(member)}
                             className="p-2 text-gray-400 hover:text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors"
                             aria-label={`View details for ${member.name}`}
+                            title={`View details for ${member.name}`}
                         >
                             <SearchIcon className="w-4 h-4" />
                         </button>


### PR DESCRIPTION
💡 What: Added a native title attribute tooltip to the "View details" icon-only button in the ActiveForce component.
🎯 Why: To provide visual hover feedback for sighted users, complementing the existing screen reader aria-label.
📸 Before/After: [See verification snapshot image]
♿ Accessibility: Improved usability for sighted users who rely on tooltips to understand icon-only buttons.

---
*PR created automatically by Jules for task [11826950497021002866](https://jules.google.com/task/11826950497021002866) started by @info-vin*