### PR TITLE
🎨 Palette: Add aria-pressed and title to GlassCrawlDepthSelector

### DIFF
--- a/archon-ui-main/src/components/ui/GlassCrawlDepthSelector.tsx
+++ b/archon-ui-main/src/components/ui/GlassCrawlDepthSelector.tsx
@@ -73,6 +73,8 @@ export const GlassCrawlDepthSelector: React.FC<GlassCrawlDepthSelectorProps> = (
                 "hover:scale-110 active:scale-95"
               )}
               aria-label={`Select crawl depth level ${level}`}
+              aria-pressed={isSelected}
+              title={getLevelDescription(level)}
             >
               {/* Outer glass layer with glow */}
               <div className={cn(


### PR DESCRIPTION
*   **💡 What:** Added `aria-pressed` state and `title` tooltips to the glass crawl depth selector buttons.
*   **🎯 Why:** To improve accessibility by clearly announcing the toggle state to screen readers, and providing native hover tooltips for visual users since these are number-only buttons.
*   **📸 Before/After:** No visual changes, added screen reader state and tooltips.
*   **♿ Accessibility:** Added `aria-pressed` to correctly announce selection state, and `title` to provide native hover descriptions.

---
*PR created automatically by Jules for task [11132115566266419958](https://jules.google.com/task/11132115566266419958) started by @info-vin*