### PR TITLE
🎨 Palette: Add ARIA label to Smart Image Picker search input

### DIFF
--- a/enduser-ui-fe/src/features/marketing/components/SmartImagePicker.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/SmartImagePicker.tsx
@@ -52,6 +52,7 @@ export const SmartImagePicker: React.FC<SmartImagePickerProps> = ({ onSelect, on
                 value={keyword}
                 onChange={(e) => send({ type: 'UPDATE_KEYWORD', keyword: e.target.value })}
                 placeholder="Search high-quality images (e.g., 'business meeting')..."
+                aria-label="Search high-quality images"
                 className="w-full pl-10 pr-4 py-3 rounded-xl border border-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 id="search-input"
               />


### PR DESCRIPTION
💡 What: Added `aria-label` to the image search input in Smart Image Picker.
🎯 Why: To improve screen reader accessibility, ensuring users know the purpose of the input field.
📸 Before/After: Screenshots captured and verified (no visual change).
♿ Accessibility: Input now correctly announces itself to assistive technologies.

---
*PR created automatically by Jules for task [3315699894858161927](https://jules.google.com/task/3315699894858161927) started by @info-vin*