### PR TITLE
🎨 Palette: Add loading state to RE-INDEX button

### DIFF
--- a/CONTRIBUTING_tw.md
+++ b/CONTRIBUTING_tw.md
@@ -424,6 +424,9 @@ Phase 4.4.5 引入了 **Clockwork** 進行系統自動檢測。
 > - `19_seed_marketing_group_chat_prompts.sql`
 > - `20_seed_supervisor_agent.sql`
 > - `21_seed_reports_workflow_prompts.sql`
+> - `22_seed_devbot_math_prompt.sql`
+> - `23_seed_agent_system_prompts.sql`
+> - `24_create_dynamic_agent_tables.sql`
 > - `99_rescue_live_data.sql`
 > - `RESET_DB.sql`
 > - `seed_blog_posts.sql`

--- a/enduser-ui-fe/src/features/manager/components/KnowledgeROI.tsx
+++ b/enduser-ui-fe/src/features/manager/components/KnowledgeROI.tsx
@@ -3,14 +3,15 @@ import {
     AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip as ReTooltip, 
     ResponsiveContainer 
 } from 'recharts';
-import { SparklesIcon } from '../../../components/Icons';
+import { SparklesIcon, RefreshCwIcon } from '../../../components/Icons';
 
 interface KnowledgeROIProps {
     knowledgeRoi: any;
     handleRebuildIndex: () => Promise<void>;
+    processingId: string | null;
 }
 
-export const KnowledgeROI: React.FC<KnowledgeROIProps> = ({ knowledgeRoi, handleRebuildIndex }) => {
+export const KnowledgeROI: React.FC<KnowledgeROIProps> = ({ knowledgeRoi, handleRebuildIndex, processingId }) => {
     return (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <div className="lg:col-span-2">
@@ -95,9 +96,18 @@ export const KnowledgeROI: React.FC<KnowledgeROIProps> = ({ knowledgeRoi, handle
                     </div>
                     <button 
                         onClick={handleRebuildIndex}
-                        className="w-full mt-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl font-black text-[10px] uppercase shadow-lg shadow-indigo-100 transition-all active:scale-95"
+                        disabled={processingId === 'rebuild_index'}
+                        className="w-full mt-6 py-3 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white rounded-xl font-black text-[10px] uppercase shadow-lg shadow-indigo-100 transition-all active:scale-95 flex items-center justify-center gap-2"
+                        aria-label="Trigger full index rebuild"
                     >
-                        TRIGGER FULL RE-INDEX
+                        {processingId === 'rebuild_index' ? (
+                            <>
+                                <RefreshCwIcon className="w-4 h-4 animate-spin" />
+                                RE-INDEXING...
+                            </>
+                        ) : (
+                            'TRIGGER FULL RE-INDEX'
+                        )}
                     </button>
                 </div>
             </div>

--- a/enduser-ui-fe/src/pages/ManagerNexus.test.tsx
+++ b/enduser-ui-fe/src/pages/ManagerNexus.test.tsx
@@ -8,7 +8,8 @@ vi.mock('../components/Icons', async (importOriginal) => {
   const actual = await importOriginal() as any;
   return {
     ...actual,
-    XIcon: (props: any) => <svg data-testid="x-icon" {...props} />
+    XIcon: (props: any) => <svg data-testid="x-icon" {...props} />,
+    RefreshCwIcon: (props: any) => <svg data-testid="refresh-icon" {...props} />
   };
 });
 

--- a/enduser-ui-fe/src/pages/ManagerNexus.tsx
+++ b/enduser-ui-fe/src/pages/ManagerNexus.tsx
@@ -145,7 +145,7 @@ export const ManagerNexus: React.FC = () => {
             case 'graph':
                 return (
                     <DetailSection title="Intelligence ROI & Graph" subtitle="60-Day Conversion Analysis (Bi-weekly)" icon={<DatabaseIcon className="w-5 h-5 text-indigo-600"/>}>
-                        <KnowledgeROI knowledgeRoi={knowledgeRoi} handleRebuildIndex={handleRebuildIndex} />
+                        <KnowledgeROI knowledgeRoi={knowledgeRoi} handleRebuildIndex={handleRebuildIndex} processingId={processingId} />
                     </DetailSection>
                 );
 


### PR DESCRIPTION
💡 **What**: Added a loading spinner to the `TRIGGER FULL RE-INDEX` button in the `KnowledgeROI` component and disabled it while processing.
🎯 **Why**: To prevent duplicate submissions and provide immediate visual feedback during network latency.
📸 **Before/After**: Button now shows `RE-INDEXING...` with a spinner and disabled state instead of doing nothing while awaiting API response.
♿ **Accessibility**: Added `aria-label` to button and implemented disabled state for screen readers.

---
*PR created automatically by Jules for task [13570203088245909985](https://jules.google.com/task/13570203088245909985) started by @info-vin*