### PR TITLE
⚡ Bolt: Optimize RAG settings fetch by parallelizing network requests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -116,3 +116,6 @@
 ## 2025-05-18 - Replacing .toLowerCase().includes() with inline regex in list rendering loops
 **Learning:** Using `string.toLowerCase().includes()` inside render functions that are executed many times per render cycle (like list items in a Kanban or Table view) causes a new lowercased string to be allocated in memory on every invocation. This leads to high Garbage Collection (GC) overhead and performance degradation during rapid state updates like mouse hovering.
 **Action:** Replace `string.toLowerCase().includes(pattern)` with an inline case-insensitive regex test like `/pattern/i.test(string)` inside high-frequency render loops to prevent redundant string memory allocations.
+## 2026-06-19 - Promise.all Optimization for RAG Settings
+**Learning:** In frontend configuration services, sequentially fetching independent data endpoints (like different credential categories) creates unnecessary waterfall delays. Decoupling them with `Promise.all` is a highly effective, safe optimization that reduces the total execution time to the duration of the longest request, significantly improving UI responsiveness when loading configuration pages.
+**Action:** When auditing data fetching functions, specifically look for sequential `await` calls that do not depend on each other's results, and refactor them into a single `Promise.all` block.

--- a/archon-ui-main/src/services/credentialsService.ts
+++ b/archon-ui-main/src/services/credentialsService.ts
@@ -115,8 +115,11 @@ class CredentialsService {
   }
 
   async getRagSettings(): Promise<RagSettings> {
-    const ragCredentials = await this.getCredentialsByCategory("rag_strategy");
-    const apiKeysCredentials = await this.getCredentialsByCategory("api_keys");
+    // PERFORMANCE: Execute independent network requests concurrently to eliminate waterfall delays
+    const [ragCredentials, apiKeysCredentials] = await Promise.all([
+      this.getCredentialsByCategory("rag_strategy"),
+      this.getCredentialsByCategory("api_keys")
+    ]);
     const settings: RagSettings = {
       USE_CONTEXTUAL_EMBEDDINGS: false,
       CONTEXTUAL_EMBEDDINGS_MAX_WORKERS: 3,


### PR DESCRIPTION
💡 What: Refactored `getRagSettings` in `credentialsService.ts` to fetch `rag_strategy` and `api_keys` credentials concurrently using `Promise.all` instead of sequentially.
🎯 Why: To eliminate an unnecessary network waterfall where the second API request had to wait for the first one to complete, reducing overall latency when loading RAG settings.
📊 Impact: Reduces the total time required to fetch complete RAG settings by executing independent requests in parallel.
🔬 Measurement: Measure the network request waterfall timeline in the browser DevTools when loading the RAG settings page or anytime `getRagSettings` is invoked. The two requests should now start simultaneously.

---
*PR created automatically by Jules for task [7663481105744337527](https://jules.google.com/task/7663481105744337527) started by @info-vin*