### PR TITLE
⚡ Bolt: Hoist Intl.DateTimeFormat to prevent unnecessary allocations in MarketingLeadsStack

### DIFF
--- a/enduser-ui-fe/src/features/marketing/components/MarketingLeadsStack.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/MarketingLeadsStack.tsx
@@ -5,6 +5,9 @@ import { EmptyState as CommonEmptyState } from '../../../components/common/Empty
 import { api } from '../../../services/api';
 import { LeadsCardStack, Lead } from './LeadsCardStack';
 
+// PERFORMANCE: Hoisted Intl.DateTimeFormat outside the component to prevent expensive re-instantiations during list rendering
+const dateFormatter = new Intl.DateTimeFormat();
+
 interface MarketingLeadsStackProps {
   leads: any[];
   isLeadsLoading: boolean;
@@ -165,7 +168,7 @@ export const MarketingLeadsStack: React.FC<MarketingLeadsStackProps> = ({
               <tbody className="divide-y divide-gray-100">
                 {sortedLeads.map(lead => (
                   <tr key={lead.id} className="hover:bg-gray-50 transition-colors">
-                    <td className="px-6 py-4 text-xs text-gray-500 whitespace-nowrap">{new Date(lead.created_at || Date.now()).toLocaleDateString()}</td>
+                    <td className="px-6 py-4 text-xs text-gray-500 whitespace-nowrap">{dateFormatter.format(new Date(lead.created_at || Date.now()))}</td>
                     <td className="px-6 py-4 min-w-0 max-w-[200px]">
                       <div className="font-medium text-gray-900 truncate" title={lead.company_name}>{lead.company_name}</div>
                       <div className="text-xs text-gray-500 truncate" title={lead.job_title}>{lead.job_title}</div>
@@ -185,7 +188,7 @@ export const MarketingLeadsStack: React.FC<MarketingLeadsStackProps> = ({
                       </div>
                     </td>
                     <td className="px-6 py-4"><a href={lead.source_job_url} target="_blank" rel="noreferrer" className="text-indigo-600 hover:underline text-xs">View Post</a></td>
-                    <td className="px-6 py-4 text-xs whitespace-nowrap">{lead.next_followup_date ? new Date(lead.next_followup_date).toLocaleDateString() : <span className="text-amber-600 bg-amber-50 px-2 py-0.5 rounded">Schedule</span>}</td>
+                    <td className="px-6 py-4 text-xs whitespace-nowrap">{lead.next_followup_date ? dateFormatter.format(new Date(lead.next_followup_date)) : <span className="text-amber-600 bg-amber-50 px-2 py-0.5 rounded">Schedule</span>}</td>
                     <td className="px-6 py-4 text-right flex justify-end gap-2">
                       <Button variant="ghost" size="sm" className="text-indigo-600 hover:bg-indigo-50" onClick={() => onOpenVisitLog(lead)} aria-label="Log Visit (Hunter Mode)" title="Log Visit (Hunter Mode)">
                         <MapPinIcon className="w-4 h-4" />


### PR DESCRIPTION
💡 What: Hoisted `Intl.DateTimeFormat` out of the `MarketingLeadsStack` render loop. Replaced `toLocaleDateString()` with a shared formatter instance using `.format()`.
🎯 Why: Calling `toLocaleDateString()` inside a list rendering loop implicitly creates a new `Intl.DateTimeFormat` object for every iteration. The constructor is expensive, causing significant CPU overhead and memory churn, especially during sorting, filtering, or list interactions.
📊 Impact: Eliminates O(N) expensive object instantiations on every render cycle of the leads table. Noticeable reduction in garbage collection overhead and CPU time when re-rendering lists.
🔬 Measurement: Check the React Profiler for the render time of `MarketingLeadsStack`. Time-to-render when sorting the table should be reduced.

---
*PR created automatically by Jules for task [4558760811749515293](https://jules.google.com/task/4558760811749515293) started by @info-vin*