### PR TITLE
🎨 Palette: Add close button to Project Modal

### DIFF
--- a/enduser-ui-fe/src/components/ProjectModal.tsx
+++ b/enduser-ui-fe/src/components/ProjectModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { api } from '../services/api';
 import { Project } from '../types';
+import { XIcon } from './Icons';
 
 interface ProjectModalProps {
   onClose: () => void;
@@ -38,7 +39,12 @@ export const ProjectModal: React.FC<ProjectModalProps> = ({ onClose, onProjectCr
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex justify-center items-center p-4" onClick={onClose}>
       <div className="bg-card rounded-lg shadow-xl p-6 w-full max-w-md relative" onClick={(e) => e.stopPropagation()}>
-        <h2 className="text-2xl font-bold mb-4">New Project</h2>
+        <div className="flex justify-between items-center mb-4 flex-shrink-0">
+          <h2 className="text-2xl font-bold">New Project</h2>
+          <button onClick={onClose} className="p-1 rounded-full hover:bg-secondary focus-visible:ring-2 focus-visible:outline-none" aria-label="Close" title="Close">
+            <XIcon className="w-6 h-6" />
+          </button>
+        </div>
         <form onSubmit={handleSubmit}>
           <div className="mb-4">
             <label htmlFor="project-title" className="block text-sm font-medium text-muted-foreground mb-1">


### PR DESCRIPTION
💡 What: Added a close (X) button to the top-right corner of the Project Modal.
🎯 Why: Users expect modals to have an explicit close button. This creates a more intuitive and consistent user experience matching the existing Task Modal.
📸 Before/After: The Project Modal now has an `XIcon` button in the header opposite the title.
♿ Accessibility: The button includes an `aria-label="Close"` and `title="Close"` for screen readers and visual users, and follows focus ring styling (`focus-visible:ring-2 focus-visible:outline-none`) for keyboard accessibility.

---
*PR created automatically by Jules for task [11143029876488203499](https://jules.google.com/task/11143029876488203499) started by @info-vin*