### PR TITLE
⚡ Bolt: [Performance] Hoist Intl.DateTimeFormat in LeadsTimeline

### DIFF
--- a/enduser-ui-fe/src/features/marketing/components/LeadsTimeline.tsx
+++ b/enduser-ui-fe/src/features/marketing/components/LeadsTimeline.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { CheckCircleIcon, ClockIcon, MapPinIcon, UserIcon } from '@/components/Icons';
 
+// PERFORMANCE: Hoist Intl.DateTimeFormat to avoid expensive instantiations inside the render loop
+const dateFormatter = new Intl.DateTimeFormat();
+
 interface TimelineEvent {
     id: string;
     type: 'creation' | 'interaction' | 'status_change' | 'visit';
@@ -47,7 +50,7 @@ export const LeadsTimeline: React.FC<LeadsTimelineProps> = ({ events }) => {
                             <div className="flex justify-between items-start mb-1">
                                 <h4 className="font-bold text-gray-800">{event.title}</h4>
                                 <span className="text-xs text-gray-400 font-mono">
-                                    {new Date(event.timestamp).toLocaleDateString()}
+                                {dateFormatter.format(new Date(event.timestamp))}
                                 </span>
                             </div>
                             <p className="text-sm text-gray-600 mb-2">{event.description}</p>


### PR DESCRIPTION
💡 What:
Hoisted `Intl.DateTimeFormat` outside the `LeadsTimeline` component and replaced `new Date().toLocaleDateString()` inside the component's render loop with `dateFormatter.format()`.

🎯 Why:
Calling `toLocaleDateString()` implicitly instantiates a new `Intl.DateTimeFormat` object under the hood, which is an expensive operation. Calling it inside a `.map()` loop during rendering causes significant performance degradation when processing many rows.

📊 Impact:
Reduces CPU cycles and memory allocations during render by reusing a single formatter instance, improving the rendering speed for lists.

🔬 Measurement:
Profile the rendering of the `LeadsTimeline` component before and after to observe reduced render times for list items.

---
*PR created automatically by Jules for task [6524430879049607836](https://jules.google.com/task/6524430879049607836) started by @info-vin*