### PR TITLE
🎨 Palette: [使用者體驗改善]

### DIFF
--- a/archon-ui-main/src/components/ui/PowerButton.tsx
+++ b/archon-ui-main/src/components/ui/PowerButton.tsx
@@ -6,6 +6,7 @@ interface PowerButtonProps {
   onClick: () => void;
   color?: 'purple' | 'green' | 'pink' | 'blue' | 'cyan' | 'orange';
   size?: number;
+  ariaLabel?: string;
 }
 
 // Helper function to get color hex values for animations
@@ -25,7 +26,8 @@ export const PowerButton: React.FC<PowerButtonProps> = ({
   isOn,
   onClick,
   color = 'blue',
-  size = 40
+  size = 40,
+  ariaLabel
 }) => {
   const colorMap = {
     purple: {
@@ -77,6 +79,8 @@ export const PowerButton: React.FC<PowerButtonProps> = ({
   return (
     <motion.button
       onClick={onClick}
+      aria-label={ariaLabel || "Toggle power"}
+      aria-pressed={isOn}
       className={`
         relative rounded-full border-2 transition-all duration-300
         ${styles.border}


### PR DESCRIPTION
💡 做了什麼: 在 `PowerButton` 元件中新增了 `aria-label` 和 `aria-pressed` 屬性，並提供自訂選項 `ariaLabel`。
🎯 為什麼: 原先這個純圖示 (icon-only) 按鈕在輔助科技（如螢幕報讀軟體）上缺乏適當的標籤來表明其功能與狀態。此次更新使其符合 WCAG 的無障礙標準，解決了設計系統日誌中所記載的核心問題。
📸 變更前後: (不適用 - 這是無形的無障礙結構變更)
♿ 無障礙改善: 補齊了反映開關狀態的 `aria-pressed` 以及能明確敘述該按鈕功能的 `aria-label`，確保依賴螢幕報讀器的使用者可以清楚理解這個按鈕的作用與目前通電狀態。

---
*PR created automatically by Jules for task [322073969933630397](https://jules.google.com/task/322073969933630397) started by @info-vin*