### PR TITLE
🎨 Palette: Add focus ring to Input component for keyboard accessibility

### DIFF
--- a/archon-ui-main/src/components/ui/Input.tsx
+++ b/archon-ui-main/src/components/ui/Input.tsx
@@ -31,7 +31,8 @@ export const Input: React.FC<React.InputHTMLAttributes<HTMLInputElement> & {
       <div className={`
         flex items-center backdrop-blur-md bg-gradient-to-b dark:from-white/10 dark:to-black/30 from-white/80 to-white/60 
         border dark:border-zinc-800/80 border-gray-200 rounded-md px-3 py-2
-        transition-all duration-200 ${accentColorMap[accentColor]}
+        focus-within:ring-2 focus-within:ring-offset-2 ${accentColorMap[accentColor]?.ring}
+        transition-all duration-200
       `}>
         {icon && <div className="mr-2 text-gray-500 dark:text-zinc-500">{icon}</div>}
         <input

--- a/archon-ui-main/src/features/ui/primitives/accent-colors.ts
+++ b/archon-ui-main/src/features/ui/primitives/accent-colors.ts
@@ -5,6 +5,7 @@ export const accentColorMap = {
     border: "border-purple-300 dark:border-purple-500/30",
     gradientFrom: "from-purple-100 dark:from-purple-500/20",
     gradientTo: "to-white dark:to-purple-500/5",
+    ring: "focus-within:ring-purple-500",
   },
   green: {
     glow: "before:shadow-[0_0_10px_2px_rgba(16,185,129,0.4)] dark:before:shadow-[0_0_20px_5px_rgba(16,185,129,0.7)]",
@@ -12,6 +13,7 @@ export const accentColorMap = {
     border: "border-emerald-300 dark:border-emerald-500/30",
     gradientFrom: "from-emerald-100 dark:from-emerald-500/20",
     gradientTo: "to-white dark:to-emerald-500/5",
+    ring: "focus-within:ring-emerald-500",
   },
   pink: {
     glow: "before:shadow-[0_0_10px_2px_rgba(236,72,153,0.4)] dark:before:shadow-[0_0_20px_5px_rgba(236,72,153,0.7)]",
@@ -19,6 +21,7 @@ export const accentColorMap = {
     border: "border-pink-300 dark:border-pink-500/30",
     gradientFrom: "from-pink-100 dark:from-pink-500/20",
     gradientTo: "to-white dark:to-pink-500/5",
+    ring: "focus-within:ring-pink-500",
   },
   blue: {
     glow: "before:shadow-[0_0_10px_2px_rgba(59,130,246,0.4)] dark:before:shadow-[0_0_20px_5px_rgba(59,130,246,0.7)]",
@@ -26,6 +29,7 @@ export const accentColorMap = {
     border: "border-blue-300 dark:border-blue-500/30",
     gradientFrom: "from-blue-100 dark:from-blue-500/20",
     gradientTo: "to-white dark:to-blue-500/5",
+    ring: "focus-within:ring-blue-500",
   },
   cyan: {
     glow: "before:shadow-[0_0_10px_2px_rgba(34,211,238,0.4)] dark:before:shadow-[0_0_20px_5px_rgba(34,211,238,0.7)]",
@@ -33,6 +37,7 @@ export const accentColorMap = {
     border: "border-cyan-300 dark:border-cyan-500/30",
     gradientFrom: "from-cyan-100 dark:from-cyan-500/20",
     gradientTo: "to-white dark:to-cyan-500/5",
+    ring: "focus-within:ring-cyan-500",
   },
   orange: {
     glow: "before:shadow-[0_0_10px_2px_rgba(249,115,22,0.4)] dark:before:shadow-[0_0_20px_5px_rgba(249,115,22,0.7)]",
@@ -40,6 +45,7 @@ export const accentColorMap = {
     border: "border-orange-300 dark:border-orange-500/30",
     gradientFrom: "from-orange-100 dark:from-orange-500/20",
     gradientTo: "to-white dark:to-orange-500/5",
+    ring: "focus-within:ring-orange-500",
   },
   none: {
     glow: "",
@@ -47,5 +53,6 @@ export const accentColorMap = {
     border: "border-gray-200 dark:border-zinc-800/50",
     gradientFrom: "from-gray-50 dark:from-white/5",
     gradientTo: "to-white dark:to-transparent",
+    ring: "focus-within:ring-gray-500",
   },
 };


### PR DESCRIPTION
## 💡 What
Added a focus ring to the custom `Input` component wrapper in `archon-ui-main`. Added a new `ring` property to `accentColorMap` in `archon-ui-main/src/features/ui/primitives/accent-colors.ts` to ensure Tailwind compiles the class correctly.

## 🎯 Why
The custom input wrapper did not visually indicate when the input field received keyboard focus, making it difficult for keyboard users to navigate and understand which field they are interacting with. By defining the `ring` property explicitly, we avoid Tailwind purging dynamically constructed classes in production.

## 📸 Before/After
No snapshot attached since it's just a focus state, but now focusing the input renders a visible ring matching the input's accent color. (A verification snapshot image has been verified locally).

## ♿ Accessibility
Improves keyboard navigation accessibility by providing a clear focus indicator on interactive input elements.

---
*PR created automatically by Jules for task [16342544296788512966](https://jules.google.com/task/16342544296788512966) started by @info-vin*