### PR TITLE
🎨 Palette: [UX improvement] Add aria-disabled and aria-busy to Button component

### DIFF
--- a/enduser-ui-fe/src/components/Button.tsx
+++ b/enduser-ui-fe/src/components/Button.tsx
@@ -91,6 +91,8 @@ export const Button: React.FC<ButtonProps> = ({
   return (
     <button
       disabled={disabled || isLoading}
+      aria-disabled={disabled || isLoading}
+      aria-busy={isLoading}
       className={`
         inline-flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-indigo-500
         ${variantClasses[variant]}


### PR DESCRIPTION
💡 What: Added aria-disabled and aria-busy attributes to the Button component in the enduser UI.
🎯 Why: To explicitly announce disabled and loading states to screen readers, improving accessibility and consistency with the main Archon UI design system.
📸 Before/After: Visuals remain unchanged. Screen reader output changes to explicitly announce "disabled" or "busy" (loading) state.
♿ Accessibility: Screen readers will now correctly read out when a button is loading or disabled.

---
*PR created automatically by Jules for task [843919725175210746](https://jules.google.com/task/843919725175210746) started by @info-vin*