### PR TITLE
Refactor: Eliminate hardcoded scene paths in MainMenuController

### DIFF
--- a/recontextualization/src/views/MainMenu.tscn
+++ b/recontextualization/src/views/MainMenu.tscn
@@ -1,10 +1,13 @@
-[gd_scene load_steps=8 format=3 uid="uid://cxab"]
+[gd_scene load_steps=11 format=3 uid="uid://cxab"]
 
 [ext_resource type="Script" path="res://src/views/MainMenu.gd" id="1_mainmenu"]
 [ext_resource type="Script" path="res://src/views/MainMenuController.gd" id="2_controller"]
 [ext_resource type="Texture2D" path="res://assets/images/bg_main_menu.png" id="3_bg"]
 [ext_resource type="Texture2D" path="res://assets/images/card_frame_blank.png" id="4_frame"]
 [ext_resource type="VideoStream" path="res://assets/videos/hero_animation.ogv" id="5_video"]
+[ext_resource type="PackedScene" path="res://src/views/TransitionVideo.tscn" id="6_transition"]
+[ext_resource type="PackedScene" path="res://src/views/CardManagementMenu.tscn" id="7_card_menu"]
+[ext_resource type="PackedScene" path="res://src/views/TeammateDashboard.tscn" id="8_teammate"]
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_btn"]
 texture = ExtResource("4_frame")
@@ -78,6 +81,9 @@ btn_quit = NodePath("UIPanel/VBoxContainer/QuitButton")
 
 [node name="Controller" type="Node" parent="."]
 script = ExtResource("2_controller")
+transition_scene = ExtResource("6_transition")
+card_menu_scene = ExtResource("7_card_menu")
+teammate_dashboard_scene = ExtResource("8_teammate")
 
 [node name="TextureRect" type="TextureRect" parent="."]
 layout_mode = 1

--- a/recontextualization/src/views/MainMenuController.gd
+++ b/recontextualization/src/views/MainMenuController.gd
@@ -1,8 +1,8 @@
 extends Node
 
-var transition_scene = "res://src/views/TransitionVideo.tscn"
-var card_menu_scene = "res://src/views/CardManagementMenu.tscn"
-var teammate_dashboard_scene = "res://src/views/TeammateDashboard.tscn"
+@export var transition_scene: PackedScene
+@export var card_menu_scene: PackedScene
+@export var teammate_dashboard_scene: PackedScene
 
 @onready var view = get_parent()
 
@@ -29,16 +29,16 @@ func _on_new_career_requested() -> void:
 		save_manager.max_player_hp = 100.0
 		save_manager.has_completed_tutorial = false
 		save_manager.save_progress()
-	if transition_scene: get_tree().change_scene_to_file(transition_scene)
+	if transition_scene: get_tree().change_scene_to_packed(transition_scene)
 
 func _on_continue_requested() -> void:
-	if transition_scene: get_tree().change_scene_to_file(transition_scene)
+	if transition_scene: get_tree().change_scene_to_packed(transition_scene)
 
 func _on_card_management_requested() -> void:
-	if card_menu_scene: get_tree().change_scene_to_file(card_menu_scene)
+	if card_menu_scene: get_tree().change_scene_to_packed(card_menu_scene)
 
 func _on_teammate_dashboard_requested() -> void:
-	if teammate_dashboard_scene: get_tree().change_scene_to_file(teammate_dashboard_scene)
+	if teammate_dashboard_scene: get_tree().change_scene_to_packed(teammate_dashboard_scene)
 
 func _on_quit_requested() -> void:
 	get_tree().quit()


### PR DESCRIPTION
## What
Refactored `MainMenuController.gd` and `MainMenu.tscn` to remove hardcoded string paths for scene transitions. 

## Why
To adhere to MVC principles and improve code safety/maintainability by leveraging Godot's Inspector for dependency injection via `@export var : PackedScene`.

## Verification
- Checked `git diff` to ensure all string paths were removed and replaced with `ExtResource` nodes injected into the Controller.
- Updated API calls from `change_scene_to_file` to `change_scene_to_packed`.

---
*PR created automatically by Jules for task [14193224754739742235](https://jules.google.com/task/14193224754739742235) started by @info-vin*