### PR TITLE
🎨 Palette: [Add aria attributes to disabled buttons]

### DIFF
--- a/enduser-ui-fe/src/pages/BlogEditor.tsx
+++ b/enduser-ui-fe/src/pages/BlogEditor.tsx
@@ -123,6 +123,8 @@ const BlogEditor: React.FC = () => {
                     <button 
                         onClick={handleSave}
                         disabled={saving}
+                        aria-disabled={saving}
+                        aria-busy={saving}
                         className="flex items-center justify-center gap-2 px-6 py-2 bg-gray-900 hover:bg-gray-800 text-white rounded-xl text-sm font-bold transition-all disabled:opacity-50 disabled:cursor-not-allowed shadow-md shadow-gray-200"
                     >
                         {saving ? <RefreshCwIcon className="w-4 h-4 animate-spin" /> : <SaveIcon className="w-4 h-4" />}

--- a/enduser-ui-fe/src/pages/BrandPage.tsx
+++ b/enduser-ui-fe/src/pages/BrandPage.tsx
@@ -178,7 +178,7 @@ const CreatePostForm: React.FC<{ post?: BlogPost | null, onSuccess: () => void, 
                 <label htmlFor="post-content" className="sr-only">Content</label>
                 <textarea id="post-content" value={content} onChange={e => setContent(e.target.value)} className="w-full p-3 border border-gray-200 dark:border-slate-700 dark:bg-slate-800 dark:text-white rounded-xl min-h-[200px] outline-none focus:ring-2 focus:ring-indigo-500 custom-scrollbar resize-none" placeholder="Content" />
             </div>
-            <button type="submit" disabled={loading} className="w-full py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-bold rounded-xl transition-colors disabled:opacity-50 shadow-lg shadow-indigo-200 dark:shadow-none">
+            <button type="submit" disabled={loading} aria-disabled={loading} aria-busy={loading} className="w-full py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-bold rounded-xl transition-colors disabled:opacity-50 shadow-lg shadow-indigo-200 dark:shadow-none">
                 {loading ? 'Saving...' : 'SAVE CHANGES'}
             </button>
         </form>


### PR DESCRIPTION
💡 What: Added `aria-disabled` and `aria-busy` attributes to disabled buttons during saving/loading states in BlogEditor and BrandPage.
🎯 Why: Enhances accessibility for screen reader users by explicitly mirroring the native disabled state and broadcasting when an asynchronous operation is in progress.
📸 Before/After: Visuals remain unchanged. Assistive technologies will now properly announce loading status.
♿ Accessibility: Ensures compliance with WCAG standards for dynamic UI elements.

---
*PR created automatically by Jules for task [3088585335449356222](https://jules.google.com/task/3088585335449356222) started by @info-vin*