### PR TITLE
⚡ Bolt: [performance improvement] - Parallelize API calls in ProviderStep

### DIFF
--- a/archon-ui-main/src/components/onboarding/ProviderStep.tsx
+++ b/archon-ui-main/src/components/onboarding/ProviderStep.tsx
@@ -25,21 +25,23 @@ export const ProviderStep = ({ onSaved, onSkip }: ProviderStepProps) => {
 
     setSaving(true);
     try {
-      // Save the API key
-      await credentialsService.createCredential({
-        key: "OPENAI_API_KEY",
-        value: apiKey,
-        is_encrypted: true,
-        category: "api_keys",
-      });
-
-      // Update the provider setting if needed
-      await credentialsService.updateCredential({
-        key: "LLM_PROVIDER",
-        value: "openai",
-        is_encrypted: false,
-        category: "rag_strategy",
-      });
+      // PERFORMANCE: Execute independent network requests concurrently to eliminate waterfall delays
+      await Promise.all([
+        // Save the API key
+        credentialsService.createCredential({
+          key: "OPENAI_API_KEY",
+          value: apiKey,
+          is_encrypted: true,
+          category: "api_keys",
+        }),
+        // Update the provider setting if needed
+        credentialsService.updateCredential({
+          key: "LLM_PROVIDER",
+          value: "openai",
+          is_encrypted: false,
+          category: "rag_strategy",
+        })
+      ]);
 
       showToast("API key saved successfully!", "success");
       // Mark onboarding as dismissed when API key is saved


### PR DESCRIPTION
💡 What: Refactored sequential await calls in handleSave to use a concurrent Promise.all block.
🎯 Why: To eliminate unnecessary network waterfalls when saving independent API keys and LLM provider configurations.
📊 Impact: Reduces total execution time of the save operation to the duration of the longest request, significantly improving UI responsiveness.
🔬 Measurement: Verified by observing the network tab to confirm both requests are initiated concurrently without waiting for the first to resolve.

---
*PR created automatically by Jules for task [6302978574098246403](https://jules.google.com/task/6302978574098246403) started by @info-vin*